### PR TITLE
Manchester rawoutput

### DIFF
--- a/RF_Receiver/RF_Receiver.ino
+++ b/RF_Receiver/RF_Receiver.ino
@@ -28,7 +28,7 @@
 
 
 #define PROGNAME               "RF_RECEIVER"
-#define PROGVERS               "3.1.1"
+#define PROGVERS               "3.1.2"
 
 #define PIN_RECEIVE            2
 #define PIN_LED                13 // Message-LED

--- a/RF_Receiver/RF_Receiver.ino
+++ b/RF_Receiver/RF_Receiver.ino
@@ -233,7 +233,7 @@ void HandleCommand(String cmd)
 
   if (cmd.charAt(0) == cmd_help) {
     //Serial.println(F("? Use one of V R i t X"));//FHEM Message
-	Serial.print(cmd_help);	Serial.print(" Use one of ");
+	Serial.print(cmd_help);	Serial.print(F(" Use one of "));
 	Serial.print(cmd_Version);Serial.print(cmd_space);
 	Serial.print(cmd_intertechno);Serial.print(cmd_space);
 	Serial.print(cmd_freeRam);Serial.print(cmd_space);

--- a/RF_Receiver/RF_Receiver.ino
+++ b/RF_Receiver/RF_Receiver.ino
@@ -28,7 +28,7 @@
 
 
 #define PROGNAME               "RF_RECEIVER"
-#define PROGVERS               "3.1.2"
+#define PROGVERS               "3.1.2a"
 
 #define PIN_RECEIVE            2
 #define PIN_LED                13 // Message-LED

--- a/RF_Receiver/RF_Receiver.ino
+++ b/RF_Receiver/RF_Receiver.ino
@@ -28,13 +28,13 @@
 
 
 #define PROGNAME               "RF_RECEIVER"
-#define PROGVERS               "2.5raw-out"
+#define PROGVERS               "3.0raw-out-alpha"
 
 #define PIN_RECEIVE            2
 #define PIN_LED                13 // Message-LED
 #define PIN_SEND               11
 #define BAUDRATE               57600
-#define FIFO_LENGTH			   100
+#define FIFO_LENGTH			   80
 //#define TX_TST
 //#define DEBUG				   1
 #include <filtering.h> //for FiFo Buffer
@@ -109,8 +109,8 @@ void loop() {
   //Serial.print("fcnt: ");   Serial.println(fifocnt);
 
 
-  static int aktVal;
-  static bool state;
+  int aktVal;
+  bool state;
   while (FiFo.getNewValue(&aktVal)) { //Puffer auslesen und an Dekoder übergeben
     //Serial.print(aktVal); Serial.print(",");
     #ifdef TX_TST
@@ -221,8 +221,8 @@ void IT_CMDs(String cmd);
 
 void HandleCommand(String cmd)
 {
-  int val;
-  String strVal;
+  //int val;
+  //String strVal;
 
   const char cmd_Version ='V';
   const char cmd_freeRam ='R';
@@ -240,9 +240,10 @@ void HandleCommand(String cmd)
 
   if (cmd.charAt(0) == cmd_help) {
     //Serial.println(F("? Use one of V R i t X"));//FHEM Message
-	Serial.print(cmd_help);	Serial.print(" Use one of");
+	Serial.print(cmd_help);	Serial.print(" Use one of ");
 	Serial.print(cmd_Version);Serial.print(cmd_space);
 	Serial.print(cmd_intertechno);Serial.print(cmd_space);
+	Serial.print(cmd_freeRam);Serial.print(cmd_space);
 	Serial.print(cmd_uptime);Serial.print(cmd_space);
 	Serial.print(cmd_changeReceiver);Serial.print(cmd_space);
 	Serial.print(cmd_changeFilter);Serial.print(cmd_space);

--- a/RF_Receiver/RF_Receiver.ino
+++ b/RF_Receiver/RF_Receiver.ino
@@ -28,7 +28,7 @@
 
 
 #define PROGNAME               "RF_RECEIVER"
-#define PROGVERS               "3.1raw-out-mc-alpha"
+#define PROGVERS               "3.1.0"
 
 #define PIN_RECEIVE            2
 #define PIN_LED                13 // Message-LED

--- a/RF_Receiver/RF_Receiver.ino
+++ b/RF_Receiver/RF_Receiver.ino
@@ -28,7 +28,7 @@
 
 
 #define PROGNAME               "RF_RECEIVER"
-#define PROGVERS               "3.0raw-out-alpha"
+#define PROGVERS               "3.1raw-out-mc-alpha"
 
 #define PIN_RECEIVE            2
 #define PIN_LED                13 // Message-LED

--- a/RF_Receiver/RF_Receiver.ino
+++ b/RF_Receiver/RF_Receiver.ino
@@ -28,7 +28,7 @@
 
 
 #define PROGNAME               "RF_RECEIVER"
-#define PROGVERS               "3.1.2a"
+#define PROGVERS               "3.1.3"
 
 #define PIN_RECEIVE            2
 #define PIN_LED                13 // Message-LED

--- a/RF_Receiver/RF_Receiver.ino
+++ b/RF_Receiver/RF_Receiver.ino
@@ -28,7 +28,7 @@
 
 
 #define PROGNAME               "RF_RECEIVER"
-#define PROGVERS               "3.1.0"
+#define PROGVERS               "3.1.1"
 
 #define PIN_RECEIVE            2
 #define PIN_LED                13 // Message-LED
@@ -355,14 +355,23 @@ void changeReciver() {
   }
 }
 
+void printFilter(uint8_t id)
+{
+	Serial.print("UPD Filter");
+	Serial.print(id);
+	Serial.print(";C=");	Serial.print(musterDec.protoID[id].clock);
+	Serial.print(";SF=");	Serial.print(musterDec.protoID[id].syncFact);
+	Serial.println(";");
+
+}
 void changeFilter()
 {
 	//cmdstring.concat(0);
 	char tmp[10];
 
-	cmdstring.toCharArray(tmp,10,1);
+	cmdstring.toCharArray(tmp,10,3);
 
-	const char *param = strtok(tmp,";");
+	char *param = strtok(tmp,";");
 	const uint8_t id = atoi(param);
 	s_sigid new_entry ={NULL,NULL,NULL,NULL,NULL,undef};
 
@@ -384,6 +393,10 @@ void changeFilter()
 		// Remove entry to filter list R;<number to remove>;
 		musterDec.protoID[id] = new_entry;
 	}
+	printFilter(id);
+	if (musterDec.numprotos+1 < id)
+		musterDec.numprotos = id+1;
+
 }
 
 

--- a/libs/RemoteSensor/examples/manchesterpattern/manchesterpattern.ino
+++ b/libs/RemoteSensor/examples/manchesterpattern/manchesterpattern.ino
@@ -26,14 +26,14 @@
 #include <patternDecoder.h>
 #include <bitstore.h>
 //Decoder
-ManchesterpatternDetector ManchesterDetect(true);
+//ManchesterpatternDetector ManchesterDetect(true);
 patternDetector ooDetect;
 patternDecoder  ooDecode;
 
-OSV2Decoder osv2Dec (&ManchesterDetect);
-ASDecoder   asDec  (&ManchesterDetect);
+//OSV2Decoder osv2Dec (&ManchesterDetect);
+//ASDecoder   asDec  (&ManchesterDetect);
 // OSV2 Data hex : DADC539E18277055                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | Detector ends here
-int sample_OSV2_data[] = {852, -1112, 356, -624, 840, -632, -1116, 840, -1104, 848, -1112, 352, -628, 836, -1124, 828, -644, -1112, 840, -1124, 832, -1116, -624, 840, -1120, 832, -1120, 836, -636, -1124, 832, -1116, -628, 840, -624, 352, -1124, 832, -1120, 836, -1116, 840, -1108, 844, -1104, 852, -1104, 364, -608, 856, -1100, 852, -1108, 848, -624, 352, -1092, 376, -604, 860, -624, 356, -1108, 356, -608, 860, -624, 352, -1092, 376, -604, 860, -604, 372, -1096, 368, -604, 864, -608, 368, -1104, 852, -1092, 372, -612, 852, -608, 368, -1092, 376, -612, 852, -3568, 864, -1080, 872, -1080, 876, -1088, 864, -1088, 868, -1092, 856, -1096, 860, -1084, 872, -1084, 868, -1100, 856, -1084, 868, -1096, 860, -1084, 868, -1080, 872, -1092, 864, -1088, 864, -1092, 864, -608, 368, -1088, 380, -592, 872, -600, 376, -1080, 388, -600, 860, -1092, 864, -600, 376, -1092, 372, -604, 864, -1088, 868, -600, 372, -1092, 864, -1084, 380, -600, 868, -1084, 868, -1088, 868, -596, 380, -1092, 376, -596, 868, -1088, 868, -1088, 864, -1092, 860, -620, 356, -1088, 868, -1088, 380, -604, 860, -608, 368, -1104, 360, -600, 868, -596, 384, -1084, 864, -1100, 364, -608, 860, -1092, 860, -1096, 860, -1096, 856, -600, 380, -1088, 860, -1092, 376, -616, 852, -612, 364, -1084, 872, -1084, 868, -1088, 376, -624, 844, -1088, 868, -596, 376, -1088, 868, -1084, 868, -1084, 384, -608, 856, -1096, 856, -1092, 864, -604, 372, -1088, 868, -1076, 392, -596, 864, -592, 388, -1084, 868, -1092, 860, -1092, 864, -1096, 860, -1092, 860, -1096, 368, -596, 868, -1088, 868, -1084, 868, -608, 372, -1092, 372, -600, 868, -604, 372, -1088, 376, -600, 864, -612, 368, -1088, 376, -608, 856, -600, 376, -1088, 380, -604, 864, -604, 372, -1080, 872, -1096, 372, -596, 868, -600, 376, -1084, 380, -604, 860, -32001, -540, -15084, -4280, -1824, -13332, -9112, -1880, -2448, -2552, -8176, -1552, -8304, -11572, -1028, -11124, -424, -8744, -524, -2728};
+int sample_OSV2_data[] = { 852, -1112, 356, -624, 840, -632, -1116, 840, -1104, 848, -1112, 352, -628, 836, -1124, 828, -644, -1112, 840, -1124, 832, -1116, -624, 840, -1120, 832, -1120, 836, -636, -1124, 832, -1116, -628, 840, -624, 352, -1124, 832, -1120, 836, -1116, 840, -1108, 844, -1104, 852, -1104, 364, -608, 856, -1100, 852, -1108, 848, -624, 352, -1092, 376, -604, 860, -624, 356, -1108, 356, -608, 860, -624, 352, -1092, 376, -604, 860, -604, 372, -1096, 368, -604, 864, -608, 368, -1104, 852, -1092, 372, -612, 852, -608, 368, -1092, 376, -612, 852, -3568, 864, -1080, 872, -1080, 876, -1088, 864, -1088, 868, -1092, 856, -1096, 860, -1084, 872, -1084, 868, -1100, 856, -1084, 868, -1096, 860, -1084, 868, -1080, 872, -1092, 864, -1088, 864, -1092, 864, -608, 368, -1088, 380, -592, 872, -600, 376, -1080, 388, -600, 860, -1092, 864, -600, 376, -1092, 372, -604, 864, -1088, 868, -600, 372, -1092, 864, -1084, 380, -600, 868, -1084, 868, -1088, 868, -596, 380, -1092, 376, -596, 868, -1088, 868, -1088, 864, -1092, 860, -620, 356, -1088, 868, -1088, 380, -604, 860, -608, 368, -1104, 360, -600, 868, -596, 384, -1084, 864, -1100, 364, -608, 860, -1092, 860, -1096, 860, -1096, 856, -600, 380, -1088, 860, -1092, 376, -616, 852, -612, 364, -1084, 872, -1084, 868, -1088, 376, -624, 844, -1088, 868, -596, 376, -1088, 868, -1084, 868, -1084, 384, -608, 856, -1096, 856, -1092, 864, -604, 372, -1088, 868, -1076, 392, -596, 864, -592, 388, -1084, 868, -1092, 860, -1092, 864, -1096, 860, -1092, 860, -1096, 368, -596, 868, -1088, 868, -1084, 868, -608, 372, -1092, 372, -600, 868, -604, 372, -1088, 376, -600, 864, -612, 368, -1088, 376, -608, 856, -600, 376, -1088, 380, -604, 864, -604, 372, -1080, 872, -1096, 372, -596, 868, -600, 376, -1084, 380, -604, 860, -32001, -540, -15084, -4280, -1824, -13332, -9112, -1880, -2448, -2552, -8176, -1552, -8304, -11572, -1028, -11124, -424, -8744, -524, -2728};
 
 const uint8_t rand_data_size=50;
 
@@ -57,6 +57,11 @@ int sample_onoff_data[]=
 int sample_AS_data[] = {-764, -524, -536, 1776, -1508, 956, -684, 1712, -784, 844, -1568, 924, -720, 1712, -808, 828, -812, 816, -820, 812, -824, 808, -1608, 880, -756, 1652, -1620, 1656, -832, 796, -844, 788, -844, 784, -844, 792, -844, 788, -844, 788, -1632, 864, -772, 1636, -856, 780, -1628, 1636, -856, 772, -860, 776, -1636, 1632, -864, 772, -860, 772, -864, 772, -860, 768, -860, 776, -860, 776, -860, 772, -780, 776, -3908, 1640, -1628, 864, -768, 1640, -852, 784, -1624, 864, -772, 1676, -848, 788, -844, 792, -844, 784, -848, 788, -1620, 868, -772, 1636, -1632, 1644, -848, 780, -852, 784, -852, 780, -848, 784, -852, 784, -844, 788, -1632, 864, -768, 1640, -852, 784, -1624, 1640, -852, 776, -852, 788, -1636, 1632, -852, 784, -852, 776, -856, 780, -852, 784, -848, 784, -852, 780, -856, 776, -776, 780};
 
 
+// This array can be filled with output from signalduino
+//uint8_t signal_Stream[]= {2,4,2,3,2,3,2,1,2,1,2,3,2,1,2,1,2,1,2,3,2,1,2,3,2,1,2,1,2,1,2,1,2,1,2,3,2,3,2,3,2,3,2,1,2,3,2,1,2,1,2,3,2,3,2,3,2,3,2,1,2,1,2,1,2,1,2,1,2,1,2,1,2,1,2,4};
+  uint8_t signal_Stream[]= {  0,3,0,2,0,1,0,2,0,2,0,2,0,1,0,1,0,1,0,2,0,1,0,1,0,2,0,1,0,1,0,1,0,1,0,1,0,2,0,2,0,2,0,2,0,1,0,2,0,2,0,2,0,2,0,2,0,2,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,3};
+int patternData[]=  { 476, -980, -1956, -4016,100  };//{-100,-988,488,-1960,-4016};
+
 int *pulsedata = sample_OSV2_data;
 uint16_t lendata = sizeof(sample_OSV2_data)/sizeof(sample_OSV2_data[0]);
 
@@ -70,6 +75,9 @@ void init_random_data()
     }
 
 }
+
+
+
 
 class DecodeOOK {
   protected:
@@ -212,7 +220,7 @@ class OregonDecoderV2 : public DecodeOOK {
     }
 };
 
-
+/*
 void detect_mc()
 {
    bool state;
@@ -236,7 +244,8 @@ void detect_mc()
    }
 
 }
-
+*/
+/*
 void decode_mc()
 {
   bool state;
@@ -273,16 +282,6 @@ void decode_mc()
 
       //delay(100);
 
-/*
-      state = asDec.decode(&sample_OSV2_data[i]); // AS Decoder
-      //delay(100);
-      if (state)
-      {
-        Serial.println("AS Message dekodiert");
-        ManchesterDetect.reset();
-        delay(1000);
-      }
-*/
   }
   if (!state)
   {
@@ -292,7 +291,7 @@ void decode_mc()
 
 }
 
-
+*/
 
 
 void decode_osv2_jeelib()
@@ -358,15 +357,14 @@ void decode_osv2_jeelib()
 void detect_onoff()
 {
   static bool state;
-  uint16_t len = sizeof(sample_onoff_data)/sizeof(sample_onoff_data[0]);
-  for (uint16_t i=0;i<=len;++i)
+  for (uint16_t i=0;i<=lendata;++i)
   {
       //Serial.print("#");Serial.println(i);
-      state = ooDetect.detect(&sample_onoff_data[i]);
+      state = ooDetect.detect(&pulsedata[i]);
       //delay(100);
       if (state)
       {
-        Serial.println("ON-OFF Message dekodiert");
+        Serial.println("Message dekodiert");
         ooDetect.reset();
         delay(1000);
       }
@@ -384,25 +382,29 @@ void detect_onoff()
 void decode_onoff()
 {
   bool state;
-  uint16_t len = sizeof(sample_onoff_data)/sizeof(sample_onoff_data[0]);
+  signalduration=0;
+
   init_random_data();
   for ( uint8_t i=0;i<=rand_data_size;i++)
   {
        state = ooDecode.decode(&random_data[i]);  // simulate some noise
   }
+
+  uint16_t i=0;
+
   for (uint8_t repeat=0;repeat<=2;repeat++)
   {
-      uint16_t i=0;
+      i=0;
       if (repeat==0) i=20;      // Simulate that we have not retrieved all from the first message
-      for (;i<=len;++i)
+      for (;i<=lendata;++i)
       {
           //Serial.print("#");Serial.println(i);
-          state = ooDecode.decode(&sample_onoff_data[i]);
+          state = ooDecode.decode(&pulsedata[i]);
           //delay(100);
-          signalduration+=abs(sample_onoff_data[i]);
+          signalduration+=abs(pulsedata[i]);
           if (state)
           {
-            Serial.println("ON-OFF Message dekodiert");
+            Serial.println("Message dekodiert");
             ooDecode.reset();
             //delay(1000);
           }
@@ -414,15 +416,46 @@ void decode_onoff()
       state =  ooDecode.decode(&random_data[i]);
   }
 
-  if (!state)
-  {
-    ooDecode.processMessage();
-    Serial.println("Message nicht dekodiert");
-    //delay(1000);
-   }
 
 }
 
+
+void decode_signalstream()
+{
+    uint16_t len = sizeof(signal_Stream)/sizeof(signal_Stream[0]);
+    init_random_data();
+       signalduration=0;
+    bool state;
+
+    for ( uint8_t i=0;i<=rand_data_size;i++)
+    {
+        state =  ooDecode.decode(&random_data[i]);
+    }
+
+    uint16_t i=0;
+    for (;i<=lendata;++i)
+    {
+      //Serial.print("#");Serial.println(i);
+      state = ooDecode.decode(&patternData[signal_Stream[i]]);
+      //delay(100);
+      signalduration+=abs(patternData[signal_Stream[i]]);
+    }
+
+    init_random_data();
+    for ( uint8_t i=0;i<=rand_data_size;i++)
+    {
+        state =  ooDecode.decode(&random_data[i]);
+    }
+
+
+    if (!state)
+    {
+    ooDecode.processMessage();
+    Serial.println("Message nicht dekodiert");
+    //delay(1000);
+    }
+
+}
 
 
 uint8_t msg=0;
@@ -435,15 +468,42 @@ void setup() {
   init_random_data();
   delay(2000);
   Serial.println("Startup:");
+  ooDecode.protoID[0]=(s_sigid){-4,-8,-18,500,0,twostate}; // Logi, TCM 97001 etc.
+  ooDecode.protoID[1]=(s_sigid){0,0,-11,560,0,twostate}; // RSL
+  ooDecode.protoID[2]=(s_sigid){0,0,0,0,0,undef}; // Free Slot
+  ooDecode.protoID[3]=(s_sigid){-1,3,-30,-1,0,tristate}; // IT old
+  ooDecode.protoID[4]=(s_sigid){0,0,-10,270,0,twostate}; // IT Autolearn
+  ooDecode.protoID[5]=(s_sigid){0,0,0,-1,0,twostate}; // Similar protocol as intertechno, but without sync
+  ooDecode.protoID[6]=(s_sigid){0,0,-36,212,0,twostate}; // Eurochron Protocol
+  ooDecode.protoID[7]=(s_sigid){0,0,-8,484,0,twostate}; // unkown Protocol
+
+  ooDecode.numprotos=8;
 
 	// Simple ON OFF Data
   Serial.print("Len Input data (onoff signal): ");
-  Serial.println(sizeof(sample_onoff_data)/sizeof(sample_onoff_data[0]));
+  Serial.println(lendata);
   Serial.println("Detecting pattern ");
   //detect_onoff();
-  uint32_t start_time=micros();
+  uint32_t start_time=0;
+  uint32_t end_time=0;
+  uint32_t duration=0;
+
+  start_time=micros();
   decode_onoff();
-  uint32_t end_time=micros();
+  end_time=micros();
+
+  duration= end_time-start_time;
+  Serial.print("Detection Time =");  Serial.print(duration);  Serial.println(" micro seconds");
+  Serial.print("Signal Time is=");  Serial.print(signalduration);  Serial.println(" micro seconds");
+
+  start_time=micros();
+  decode_signalstream();
+  end_time=micros();
+  duration= end_time-start_time;
+
+  Serial.print("Detection Time =");  Serial.print(duration);  Serial.println(" micro seconds");
+  Serial.print("Signal Time is=");  Serial.print(signalduration);  Serial.println(" micro seconds");
+
 /*
 	// OSV2 Data
 
@@ -468,9 +528,6 @@ void setup() {
 //  randomize_signal();
 //  detect();
 */
-  uint32_t duration= end_time-start_time;
-  Serial.print("Detection Time =");  Serial.print(duration);  Serial.println(" micro seconds");
-  Serial.print("Signal Time is=");  Serial.print(signalduration);  Serial.println(" micro seconds");
 
 
 

--- a/libs/RemoteSensor/patternDecoder.cpp
+++ b/libs/RemoteSensor/patternDecoder.cpp
@@ -126,7 +126,7 @@ bool patternBasic::validSequence(int *a, int *b)
 
     //return ((*a> 0 and 0 > *b) or (*b > 0  and 0 > *a));
     //return ((*a)*(*b)<0);
-    return ((*a ^ *b) < 0); // true iff a and b have opposite signs
+    return ((*a ^ *b) < 0); // true if a and b have opposite signs
 
 }
 
@@ -160,7 +160,7 @@ void patternDetector::reset() {
 	state = searching;
 	clock = sync=-1;
 	for (uint8_t i=0; i<maxNumPattern;++i)
-		histo[0]=pattern[i][0]=0;
+		histo[i]=pattern[i][0]=0;
 	success = false;
 	tol = 150; //
 	tolFact = 0.3;
@@ -364,7 +364,7 @@ void patternDetector::doDetectwoSync() {
 		bitcnt = 0;
 
         valid=validSequence(first,last);
-        valid&=!(messageLen+1 == maxMsgSize*8);
+        valid &= (messageLen+1 == maxMsgSize*8) ? false : true;
 		if (pattern_pos > patternLen) patternLen=pattern_pos;
 		if (messageLen ==0) valid=pattern_pos=patternLen=0;
 
@@ -409,6 +409,10 @@ void patternDetector::doDetectwoSync() {
           pattern_pos=0;
           //doDetectwoSync(); //Sichert den aktuellen Puls nach dem Reset, da wir ihn ggf. noch benötigen
           return;
+        } else if (!valid) {
+			reset();
+			success=false;
+			pattern_pos=0;
         }
 
 		/*else {

--- a/libs/RemoteSensor/patternDecoder.cpp
+++ b/libs/RemoteSensor/patternDecoder.cpp
@@ -735,8 +735,7 @@ void patternDecoder::processMessage()
 		ManchesterpatternDecoder mcdecoder(this);			// Init Manchester Decoder class
 
 		mcdecoder.reset();
-		mcdecoder.isManchester();
-		/*
+
 		if (mcdecoder.isManchester())// && mcdecoder.doDecode())	// Check if valid manchester pattern and try to decode
 		{
 			//String mcbitmsg;
@@ -757,7 +756,7 @@ void patternDecoder::processMessage()
 			// Output Manchester Bits
 			//printMsgStr(&preamble,&mcbitmsg,&postamble);
 		} else {
-		*/
+
 			//preamble = String(MSG_START)+String("MU")+String(SERIAL_DELIMITER)+preamble;
 
 			preamble.concat("MU");
@@ -779,7 +778,7 @@ void patternDecoder::processMessage()
 
 			printMsgRaw(0,messageLen,&preamble,&postamble);
 			//ITTX Protokoll z.B.
-		//}
+		}
 
 		success = true;
 

--- a/libs/RemoteSensor/patternDecoder.cpp
+++ b/libs/RemoteSensor/patternDecoder.cpp
@@ -63,6 +63,9 @@ void patternBasic::reset()
 	clock = -1;
 	patternStore->reset();
     tol=0;
+	for (int i=0;i<maxNumPattern;i++)
+        pattern[i][0]=0;
+
 }
 
 bool patternBasic::detect(int* pulse){
@@ -378,7 +381,7 @@ void patternDetector::doDetectwoSync() {
 	//Serial.print("bitcnt:");Serial.println(bitcnt);
 
 	if (messageLen+1 >= maxMsgSize*8) {
-		#if DEBUGDETECT>=0
+		#if DEBUGDETECT>0
 		Serial.println("Error, overflow in message Array");
 		#endif
 	    processMessage();
@@ -391,9 +394,7 @@ void patternDetector::doDetectwoSync() {
 		static uint8_t pattern_pos;
         bool valid;
         bool add_new_pattern=true;
-
 		bitcnt = 0;
-
         valid=validSequence(first,last);
         valid &= (messageLen+1 == maxMsgSize*8) ? false : true;
 		if (pattern_pos > patternLen) patternLen=pattern_pos;
@@ -411,14 +412,11 @@ void patternDetector::doDetectwoSync() {
 		Serial.print(F(", mLen: ")); Serial.print(messageLen);
 		#endif
 
-
-
-
 		if (0<=fidx){
 			//gefunden
 			message[messageLen]=fidx;
 			if (messageLen>1 && message[messageLen-1] == message[messageLen]) reset();  // haut Rauschen weg.
-			//pattern[fidx][0] = (pattern[fidx][0]+seq[1])/2;
+			pattern[fidx][0] = (pattern[fidx][0]+seq[1])/2; // Moving average
 			messageLen++;
 			add_new_pattern=false;
         }   else {
@@ -430,7 +428,6 @@ void patternDetector::doDetectwoSync() {
                 add_new_pattern=false;
             }
         }
-
 
         if (!valid && messageLen>=minMessageLen){
 
@@ -445,7 +442,6 @@ void patternDetector::doDetectwoSync() {
 			success=false;
 			pattern_pos=0;
         }
-
 		/*else {
 			if (messageLen>=minMessageLen){
 				// Annahme, wir haben eine Nachricht empfangen, jetzt kommt rauschen, welches nicht zum Muster passt

--- a/libs/RemoteSensor/patternDecoder.cpp
+++ b/libs/RemoteSensor/patternDecoder.cpp
@@ -1466,21 +1466,30 @@ bool ManchesterpatternDecoder::doDecode() {
 
             if (isLong(pdec->message[i])) {
 		          ManchesterBits->addValue(!(pdec->pattern[pdec->message[i]][0] >>15)); // Check if bit 15 is set
+				  #ifdef DEBUGDECODE
 		          Serial.print("L");
+		          #endif
             }
 			else if(isShort(pdec->message[i]) && i < pdec->messageLen-1 && isShort(pdec->message[i+1])  )
 			{
-				  ManchesterBits->addValue(!(pdec->pattern[pdec->message[i]][0] >>15)); // Check if bit 15 is set
+				  ManchesterBits->addValue(!(pdec->pattern[pdec->message[i+1]][0] >>15)); // Check if bit 15 is set
+				  #ifdef DEBUGDECODE
 				  Serial.print("SS");
+				  #endif
+
 				  i++;
 			}
 			else {
 				if (i < pdec->messageLen-minbitlen)
 				{
 					ManchesterBits->reset();
+					#ifdef DEBUGDECODE
 					Serial.print("RES");
+					#endif
 				} else {
+					#ifdef DEBUGDECODE
 					Serial.print("END");
+					#endif
 					return (ManchesterBits->valcount >= minbitlen);  // Min 20 Bits needed
 				}
 			}

--- a/libs/RemoteSensor/patternDecoder.cpp
+++ b/libs/RemoteSensor/patternDecoder.cpp
@@ -1425,7 +1425,7 @@ bool ManchesterpatternDecoder::doDecode() {
 	bool mc_start_found=false;
 	while (i < pdec->messageLen)
 	{
-		if ( isLong(pdec->message[i]) ||  isShort(pdec->message[i])  )
+		if ( mc_start_found==false && isLong(pdec->message[i]) ||  isShort(pdec->message[i])  )
 		{
 			pdec->mstart=i;
 			mc_start_found=true;
@@ -1441,7 +1441,7 @@ bool ManchesterpatternDecoder::doDecode() {
 			{
 				  ManchesterBits->addValue(!(pdec->pattern[pdec->message[i]][0] >>15)); // Check if bit 15 is set
 				  //Serial.print("SS");
-				  ++i;
+				  i++;
 			}
 			else {
 				return (ManchesterBits->valcount >= minbitlen);  // Min 20 Bits needed
@@ -2058,6 +2058,7 @@ OSV2Decoder::OSV2Decoder(ManchesterpatternDetector *detector)
 
 /*
 The Sync signal begins really with 01, so we need to start decoding at first 01 pattern, not 10. 10 is caused by the startingpoint of the signal
+
 
 Sync
 10 10 10 10 10 10 10 10

--- a/libs/RemoteSensor/patternDecoder.cpp
+++ b/libs/RemoteSensor/patternDecoder.cpp
@@ -708,18 +708,19 @@ void patternDecoder::processMessage()
 
 
 		ManchesterpatternDecoder mcdecoder(this);				// Init Manchester Decoder class
-		if (mcdecoder.isManchester() && mcdecoder.doDecode())	// Check if valid manchester pattern and try to decode
+		if (mcdecoder.isManchester() )//&& mcdecoder.doDecode())	// Check if valid manchester pattern and try to decode
 		{
+			return;
 			String mcbitmsg;
 			mcdecoder.getMessageHexStr(&mcbitmsg);
 
-			preamble = String("MC")+preamble+String(SERIAL_DELIMITER);
+			preamble = String("MC")+String(SERIAL_DELIMITER)+preamble;
 			//preamble.concat("MC"); ; preamble.concat(SERIAL_DELIMITER);  // Message Index
 
 			// Output Manchester Bits
-			printMsgStr(&preamble,&mcbitmsg,&postamble);
+			//printMsgStr(&preamble,&mcbitmsg,&postamble);
 		} else {
-			preamble = String("MU")+preamble+String(SERIAL_DELIMITER);
+			preamble = String("MU")+String(SERIAL_DELIMITER)+preamble;
 
 			printMsgRaw(0,messageLen,&preamble,&postamble);
 			/*
@@ -760,7 +761,7 @@ void patternDecoder::printMsgRaw(uint8_t m_start, uint8_t m_end, String *preambl
 
 	//Serial.print(*preamble);
 	String msg;
-	msg.reserve(m_end-mstart);
+	//msg.reserve(m_end-mstart);
 
 	for (;m_start<=m_end;m_start++)
 	{
@@ -804,13 +805,13 @@ bool patternDecoder::checkEV1527type(s_sigid match){
 	#endif
 	return valid;  // Skip further investigation of protocol and do this in FHEM
 
-
+/*
 
 	int check_vals[3] = {2,0,0};
-	/*
-	check_vals[1]= match.clock;
-	check_vals[2]= match.lowFact* match.clock;
-	*/
+
+	//check_vals[1]= match.clock;
+	//check_vals[2]= match.lowFact* match.clock;
+
 	check_vals[1]= 1; // Clock fact
 	check_vals[2]= match.lowFact;
 
@@ -826,6 +827,7 @@ bool patternDecoder::checkEV1527type(s_sigid match){
 		Serial.print(valid);
 	#endif
 	return valid;
+*/
 }
 
 bool patternDecoder::checkSignal(const s_sigid s_signal)

--- a/libs/RemoteSensor/patternDecoder.cpp
+++ b/libs/RemoteSensor/patternDecoder.cpp
@@ -678,8 +678,7 @@ void patternDecoder::processMessage()
 		Serial.print(" - MEFound: "); Serial.println(m_endfound);
 		Serial.print(" - MEnd: "); Serial.println(mend);
 		#endif // DEBUGDECODE
-
-		if (m_endfound && mend - mstart >= minMessageLen)	// Check if message Length is long enough
+		if ((m_endfound && mend - mstart >= minMessageLen) || (!m_endfound && messageLen < (maxMsgSize*8)))	// Check if message Length is long enough
 		{
             #ifdef DEBUGDECODE
             Serial.println("Filter Match: ");;

--- a/libs/RemoteSensor/patternDecoder.cpp
+++ b/libs/RemoteSensor/patternDecoder.cpp
@@ -736,10 +736,10 @@ void patternDecoder::processMessage()
 
 		mcdecoder.reset();
 
-		if (mcdecoder.isManchester())// && mcdecoder.doDecode())	// Check if valid manchester pattern and try to decode
+		if (mcdecoder.isManchester() && mcdecoder.doDecode())	// Check if valid manchester pattern and try to decode
 		{
-			//String mcbitmsg;
-			//mcdecoder.getMessageHexStr(&mcbitmsg);
+			String mcbitmsg;
+			mcdecoder.getMessageHexStr(&mcbitmsg);
 
 			preamble.concat("MC");
 			preamble.concat(SERIAL_DELIMITER);
@@ -749,12 +749,12 @@ void patternDecoder::processMessage()
 			postamble.concat('\n');
 
 			//preamble = String(MSG_START)+String("MC")+String(SERIAL_DELIMITER)+preamble;
-			printMsgRaw(0,messageLen,&preamble,&postamble);
+			//printMsgRaw(0,messageLen,&preamble,&postamble);
 
 			//preamble.concat("MC"); ; preamble.concat(SERIAL_DELIMITER);  // Message Index
 
 			// Output Manchester Bits
-			//printMsgStr(&preamble,&mcbitmsg,&postamble);
+			printMsgStr(&preamble,&mcbitmsg,&postamble);
 		} else {
 
 			//preamble = String(MSG_START)+String("MU")+String(SERIAL_DELIMITER)+preamble;

--- a/libs/RemoteSensor/patternDecoder.cpp
+++ b/libs/RemoteSensor/patternDecoder.cpp
@@ -836,12 +836,13 @@ Checks Clock, Sync, low and high puls fact
 Returns true if all values match
 */
 bool patternDecoder::checkEV1527type(s_sigid match){
+
+	if (match.syncFact==0) // No Sync fact -> no sync check, filter not valid here
+	{
+		return false;
+	}
 	bool valid = true;
-	/*valid &= messageLen==Length;
-	#ifdef DEBUGDECODE
-		Serial.print(valid);
-	#endif
-	*/
+
 	if (match.clock !=0 )
 	{
 		if (match.clock == -1)  // Auto Mode

--- a/libs/RemoteSensor/patternDecoder.cpp
+++ b/libs/RemoteSensor/patternDecoder.cpp
@@ -741,6 +741,7 @@ void patternDecoder::processMessage()
 
 			String mcbitmsg;
 			//Serial.println("MC");
+			mcbitmsg ="D=";
 			mcdecoder.getMessageHexStr(&mcbitmsg);
    		    //Serial.println("f");
 

--- a/libs/RemoteSensor/patternDecoder.cpp
+++ b/libs/RemoteSensor/patternDecoder.cpp
@@ -212,12 +212,13 @@ bool patternDetector::getSync(){
 				// Prüfe ob Sync und Clock valide sein können
 				if (histo[p] > 6) continue;    // Maximal 6 Sync Pulse  Todo: 6 Durch Formel relativ zu messageLen ersetzen
 
-				// Prüfen ob der gefundene Sync auch als message [i, p] vorkommt
-				uint8_t c = 1;
+				// Prüfen ob der gefundene Sync auch als message [clock, p] vorkommt
+				uint8_t c = 0;
 				while (c < messageLen)		// Todo: Abstand zum Ende berechnen, da wir eine mindest Nachrichtenlänge nach dem sync erwarten, brauchen wir nicht bis zum Ende suchen.
 				{
 					//if (message[c] == clock && message[c+1] == p) break;
-					if (message[c] == p && message[c-1] == clock) break;   // Faster version as bevore
+					//if (message[c] == p && message[c-1] == clock) break;   // Faster version as bevore, but does not work
+					if (message[c+1] == p && message[c] == clock ) break;	// Fast as bevore and works.
 					c++;
 				}
 

--- a/libs/RemoteSensor/patternDecoder.h
+++ b/libs/RemoteSensor/patternDecoder.h
@@ -168,7 +168,7 @@ class patternDetector : protected patternBasic {
 		*/
 	    uint8_t histo[maxNumPattern];
 	    uint8_t mstart; // Temp Variable zum Testen
-    	s_sigid protoID[10]; // Speicher für Protokolldaten
+    	s_sigid protoID[30]; // Speicher für Protokolldaten
     	uint8_t numprotos;// Number of protocols in protoID
 
 };

--- a/libs/RemoteSensor/patternDecoder.h
+++ b/libs/RemoteSensor/patternDecoder.h
@@ -53,7 +53,7 @@ const char SERIAL_DELIMITER =';';
 const char MSG_START =0x2;			// this is a non printable Char
 const char MSG_END =0x3;			// this is a non printable Char
 
-//#define DEBUGDETECT 0
+//#define DEBUGDETECT 1
 //#define DEBUGDETECT 255  // Very verbose output
 //#define DEBUGDECODE 2
 
@@ -101,7 +101,6 @@ enum mt {twostate,tristate,undef};
 		bool inTol(int val, int set);           // checks if a value is in tolerance range
 		bool inTol(int val, int set, int tolerance);
         bool validSequence(int *a, int *b);     // checks if two pulses are basically valid in terms of on-off signals
-
 		enum status {searching, clockfound, syncfound,detecting};
 
         virtual void doSearch();                // Virtual class which must be implemented in a child class
@@ -138,6 +137,7 @@ class patternDetector : protected patternBasic {
 		void reset();
 		bool getSync();	 // Searches clock and sync in given Signal
 		bool getClock(); // Searches a clock in a given signal
+		bool validSignal();						// Checks if stored message belongs to a validSignal
 		virtual void processMessage();
 		int8_t getPatternIndex(int key);
 
@@ -183,28 +183,32 @@ class patternDecoder : public patternDetector{
 	public:
 		patternDecoder();
 
-		uint8_t twoStateMessageBytes(const s_pidx s_patt);
-		void twoStateMessageBytes() {};
-		void triStateMessageBytes();
+		bool decode(int* pulse);
+		void processMessage();
+		bool checkSignal(const s_sigid s_signal);
+		bool checkEV1527type(s_sigid match);
+
 
 		void printMsgStr(String *first, String *second, String *third);
 		void printMsgRaw(uint8_t start, uint8_t end,String *preamble=NULL,String *postamble=NULL);
 		void printMessageHexStr();
-		uint8_t printTristateMessage(const s_pidx s_patt);
-		void printNewITMessage();
 
-		bool decode(int* pulse);
 
-		void processMessage();
 
-		bool checkSignal(const s_sigid s_signal);
-		bool checkEV1527type(s_sigid match);
 
 		void checkLogilink();
 		void checkITold();
 		void checkITautolearn();
 		void checkAS();
 		void checkTCM97001();
+
+		uint8_t twoStateMessageBytes(const s_pidx s_patt);
+		void twoStateMessageBytes() {};
+		void triStateMessageBytes();
+		uint8_t printTristateMessage(const s_pidx s_patt);
+		void printNewITMessage();
+	private:
+
 
 		//uint8_t byteMessage[maxMsgSize];
 		//byte byteMessageLen;
@@ -217,14 +221,13 @@ class ManchesterpatternDecoder
 	ManchesterpatternDecoder(patternDecoder *ref_dec);
 	bool doDecode();
 	void setMinBitLen(uint8_t len);
-    bool manchesterfound();         // returns true if the detection engine has found a manchester sequence. Returns true not bevore other signals will be processed
     void getMessageHexStr(String *message);
     bool isManchester();
+	void reset();
 
 
 
 	private:
-	void reset();
 	bool isLong(uint8_t pulse_idx);
 	bool isShort(uint8_t pulse_idx);
 	unsigned char getMCByte(uint8_t idx); // Returns one Manchester byte in correct order. This is a helper function to retrieve information out of the buffer
@@ -236,8 +239,8 @@ class ManchesterpatternDecoder
     int8_t longhigh;
     int8_t shortlow;
     int8_t shorthigh;
-    int clock;						// Manchester calculated clock
-    int dclock;						// Manchester calculated double clock
+//    int clock;						// Manchester calculated clock
+//    int dclock;						// Manchester calculated double clock
 
 	uint8_t minbitlen;
 

--- a/libs/RemoteSensor/patternDecoder.h
+++ b/libs/RemoteSensor/patternDecoder.h
@@ -43,7 +43,7 @@
 const uint8_t maxNumPattern=6;
 const uint8_t maxMsgSize=30;
 const uint8_t minMessageLen=40;
-const uint8_t syncMinFact=9;
+const uint8_t syncMinFact=8;
 const uint8_t prefixLen=3;
 
 const int16_t maxPulse = 32001;  // Magic Pulse Length

--- a/libs/RemoteSensor/patternDecoder.h
+++ b/libs/RemoteSensor/patternDecoder.h
@@ -53,9 +53,9 @@ const char SERIAL_DELIMITER =';';
 const char MSG_START =0x2;			// this is a non printable Char
 const char MSG_END =0x3;			// this is a non printable Char
 
-//#define DEBUGDETECT 2
+//#define DEBUGDETECT 0
 //#define DEBUGDETECT 255  // Very verbose output
-//#define DEBUGDECODE 3
+//#define DEBUGDECODE 1
 
 #define PATTERNSIZE 2
 
@@ -156,6 +156,8 @@ class patternDetector : protected patternBasic {
 		uint8_t bitcnt;
 		uint8_t message[maxMsgSize*8];
 		uint8_t messageLen;
+  		bool m_truncated;     // Identify if message has been truncated
+
 		/*
 		int buffer[2];
 		int* first;
@@ -182,6 +184,7 @@ class patternDecoder : public patternDetector{
 	friend class ManchesterpatternDecoder;
 	public:
 		patternDecoder();
+		void reset();
 
 		bool decode(int* pulse);
 		void processMessage();
@@ -191,6 +194,7 @@ class patternDecoder : public patternDetector{
 		void printMsgStr(String *first, String *second, String *third);
 		void printMsgRaw(uint8_t start, uint8_t end,String *preamble=NULL,String *postamble=NULL);
 		void printMessageHexStr();
+
 
 		void checkLogilink();
 		void checkITold();

--- a/libs/RemoteSensor/patternDecoder.h
+++ b/libs/RemoteSensor/patternDecoder.h
@@ -53,9 +53,9 @@ const char SERIAL_DELIMITER =';';
 const char MSG_START =0x2;			// this is a non printable Char
 const char MSG_END =0x3;			// this is a non printable Char
 
-//#define DEBUGDETECT 1
+//#define DEBUGDETECT 2
 //#define DEBUGDETECT 255  // Very verbose output
-//#define DEBUGDECODE 2
+//#define DEBUGDECODE 3
 
 #define PATTERNSIZE 2
 

--- a/libs/RemoteSensor/patternDecoder.h
+++ b/libs/RemoteSensor/patternDecoder.h
@@ -219,6 +219,7 @@ class ManchesterpatternDecoder
 {
 	public:
 	ManchesterpatternDecoder(patternDecoder *ref_dec);
+	~ManchesterpatternDecoder();
 	bool doDecode();
 	void setMinBitLen(uint8_t len);
     void getMessageHexStr(String *message);

--- a/libs/RemoteSensor/patternDecoder.h
+++ b/libs/RemoteSensor/patternDecoder.h
@@ -138,7 +138,6 @@ class patternDetector : protected patternBasic {
 		void reset();
 		bool getSync();	 // Searches clock and sync in given Signal
 		bool getClock(); // Searches a clock in a given signal
-		bool isManchester();	// Checks if Signal is manchester style
 		virtual void processMessage();
 		int8_t getPatternIndex(int key);
 
@@ -188,6 +187,7 @@ class patternDecoder : public patternDetector{
 		void twoStateMessageBytes() {};
 		void triStateMessageBytes();
 
+		void printMsgStr(String *first, String *second, String *third);
 		void printMsgRaw(uint8_t start, uint8_t end,String *preamble=NULL,String *postamble=NULL);
 		void printMessageHexStr();
 		uint8_t printTristateMessage(const s_pidx s_patt);
@@ -213,29 +213,33 @@ class patternDecoder : public patternDetector{
 
 class ManchesterpatternDecoder
 {
+	public:
 	ManchesterpatternDecoder(patternDecoder *ref_dec);
 	bool doDecode();
+	void setMinBitLen(uint8_t len);
+    bool manchesterfound();         // returns true if the detection engine has found a manchester sequence. Returns true not bevore other signals will be processed
+    void getMessageHexStr(String *message);
+    bool isManchester();
+
+
+
+	private:
 	void reset();
 	bool isLong(uint8_t pulse_idx);
 	bool isShort(uint8_t pulse_idx);
-    bool manchesterfound();         // returns true if the detection engine has found a manchester sequence. Returns true not bevore other signals will be processed
-    void getMessageHexStr();
-	bool isManchester();
-	void setMinBitLen(uint8_t len);
+	unsigned char getMCByte(uint8_t idx); // Returns one Manchester byte in correct order. This is a helper function to retrieve information out of the buffer
 
     BitStore *ManchesterBits;       // A store using 1 bit for every value stored. It's used for storing the Manchester bit data in a efficent way
     patternDecoder *pdec;
+
+    int8_t longlow;
+    int8_t longhigh;
+    int8_t shortlow;
+    int8_t shorthigh;
     int clock;						// Manchester calculated clock
     int dclock;						// Manchester calculated double clock
 
-    uint8_t longlow;
-    uint8_t longhigh;
-    uint8_t shortlow;
-    uint8_t shorthigh;
-
 	uint8_t minbitlen;
-    unsigned char getMCByte(uint8_t idx); // Returns one Manchester byte in correct order. This is a helper function to retrieve information out of the buffer
-
 
 };
 /*

--- a/libs/RemoteSensor/patternDecoder.h
+++ b/libs/RemoteSensor/patternDecoder.h
@@ -53,11 +53,11 @@ const char SERIAL_DELIMITER =';';
 const char MSG_START =0x2;			// this is a non printable Char
 const char MSG_END =0x3;			// this is a non printable Char
 
-//#define DEBUGDETECT 0
+//#define DEBUGDETECT 2
 //#define DEBUGDETECT 255  // Very verbose output
 //#define DEBUGDECODE 1
 
-#define PATTERNSIZE 2
+#define PATTERNSIZE 1
 
 #define DEBUG_BEGIN(i) Serial.print(F("(D:"));Serial.print(i);
 #define DEBUG_END Serial.println(F(")"));

--- a/libs/RemoteSensor/patternDecoder.h
+++ b/libs/RemoteSensor/patternDecoder.h
@@ -188,13 +188,9 @@ class patternDecoder : public patternDetector{
 		bool checkSignal(const s_sigid s_signal);
 		bool checkEV1527type(s_sigid match);
 
-
 		void printMsgStr(String *first, String *second, String *third);
 		void printMsgRaw(uint8_t start, uint8_t end,String *preamble=NULL,String *postamble=NULL);
 		void printMessageHexStr();
-
-
-
 
 		void checkLogilink();
 		void checkITold();
@@ -209,7 +205,6 @@ class patternDecoder : public patternDetector{
 		void printNewITMessage();
 	private:
 
-
 		//uint8_t byteMessage[maxMsgSize];
 		//byte byteMessageLen;
 
@@ -223,10 +218,10 @@ class ManchesterpatternDecoder
 	bool doDecode();
 	void setMinBitLen(uint8_t len);
     void getMessageHexStr(String *message);
+    void getMessagePulseStr(String *str);
+    void getMessageClockStr(String* str);
     bool isManchester();
 	void reset();
-
-
 
 	private:
 	bool isLong(uint8_t pulse_idx);
@@ -240,11 +235,10 @@ class ManchesterpatternDecoder
     int8_t longhigh;
     int8_t shortlow;
     int8_t shorthigh;
-//    int clock;						// Manchester calculated clock
+    int clock;						// Manchester calculated clock
 //    int dclock;						// Manchester calculated double clock
 
 	uint8_t minbitlen;
-
 };
 /*
     Detector for manchester Signals. It uses already the toolset from patternBasic.
@@ -275,9 +269,6 @@ class ManchesterpatternDetector : public patternBasic {
         unsigned char reverseByte(unsigned char original);  // Not needed anymore
    		//uint8_t message[maxMsgSize*8];
 		bool silent;                    // True to suspress output, which is the default
-
-
-
 };
 
 /*

--- a/libs/bitstore/bitstore.cpp
+++ b/libs/bitstore/bitstore.cpp
@@ -31,6 +31,16 @@ BitStore::BitStore(uint8_t bitlength,uint8_t bufsize)
     }
 }
 
+/** @brief (one liner)
+  *
+  * (documentation goes here)
+  */
+ BitStore::~BitStore()
+{
+	free(datastore);
+}
+
+
 void BitStore::addValue(char value)
 {
     if (bytecount >=buffsize ) return; // Out of Buffer
@@ -84,7 +94,7 @@ void BitStore::reset()
 {
   for (uint8_t i=0;i<buffsize;i++)
   {
-      datastore[i]=0;
+      datastore[i]=NULL;
   }
   bytecount=0;
   valcount=0;

--- a/libs/bitstore/bitstore.cpp
+++ b/libs/bitstore/bitstore.cpp
@@ -86,6 +86,7 @@ unsigned char BitStore::getValue(uint8_t pos)
 
 unsigned char BitStore::getByte(uint8_t idx)
 {
+  if (idx >= buffsize) return -1; // Out of buffer range
   return (datastore[idx]);
 }
 

--- a/libs/bitstore/bitstore.cpp
+++ b/libs/bitstore/bitstore.cpp
@@ -22,7 +22,7 @@ BitStore::BitStore(uint8_t bitlength,uint8_t bufsize)
 {
     valuelen = bitlength; // How many bits shoudl be reserved for one value added ?
     bmask=0;
-    BitStore::buffsize = bufsize;
+    buffsize = bufsize;
     datastore= (unsigned char*) calloc(bufsize,sizeof(char)); // Speicher allokieren und 0 zuweisen
     reset();
     for (uint8_t x=7;x>(7-valuelen);x--)

--- a/libs/bitstore/bitstore.h
+++ b/libs/bitstore/bitstore.h
@@ -26,6 +26,7 @@ class BitStore
     public:
         /** Default constructor */
         BitStore(uint8_t bitlength=2, uint8_t bufsize=10);
+        ~BitStore();
         void addValue(char value);
         unsigned char getValue(uint8_t pos);
         const uint8_t getSize();
@@ -34,12 +35,10 @@ class BitStore
         unsigned char getByte(uint8_t idx);
         uint8_t bytecount;  // Number of stored values
         uint8_t valcount;  // Number of total values stored
-
     protected:
 
     private:
         uint8_t valuelen;   // Number of bits for every value
-
         uint8_t bmask;
         uint8_t bcnt;
         uint8_t buffsize;

--- a/libs/bitstore/bitstore.h
+++ b/libs/bitstore/bitstore.h
@@ -33,7 +33,7 @@ class BitStore
         unsigned char *datastore;  // Reserve 40 Bytes for our store. Should be edited to aa dynamic way
         void reset();
         unsigned char getByte(uint8_t idx);
-        uint8_t bytecount;  // Number of stored values
+        uint8_t bytecount;  // Number of stored bytes
         uint8_t valcount;  // Number of total values stored
     protected:
 


### PR DESCRIPTION


- Added ability to detect manchester encoding and convert it directly to a bitstream. Message will be reported in hex via serial
- Uses no longer a filter for synced messages, they are all reported as MS without detection of the protocol type.
- pulse length going trough a over all average to be more accurate
- receiver now has a option to send via raw data
- improved handling of sending messages to avoid collisions when receiving
- some code cleanup (removed some unused functions)
- removed garbage before message start is detected to get rid of useless data
- improved buffer full handling 
- serval fixes and stability improvements
