### PR TITLE
WIP: Dev r33 fixmc in cc1101 überführen 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,4 +45,4 @@ deploy:
     repo: RFD-FHEM/SIGNALESP
     tags: true
     condition: "$TRAVIS_TAG =~ ^release.*$"
-    branch: dev-cc1101
+    branch: dev-r33_cc1101

--- a/RF_Receiver/RF_Receiver.ino
+++ b/RF_Receiver/RF_Receiver.ino
@@ -49,8 +49,11 @@
 		#define PIN_SEND              3   // gdo0Pin TX out
 	    #define PIN_RECEIVE           2
 	#endif
-
-  #endif
+#else
+	#define PIN_RECEIVE            2
+	#define PIN_LED                13 // Message-LED
+	#define PIN_SEND               11
+#endif
 
 
 #define BAUDRATE               57600

--- a/RF_Receiver/RF_Receiver.ino
+++ b/RF_Receiver/RF_Receiver.ino
@@ -31,14 +31,15 @@
 */
 //#define CMP_MEMDBG 1
 
-#define CMP_CC1101
+//#define CMP_CC1101
 
+#define PROGVERS               "3.3.1-dev"
 #define PROGNAME               "RF_RECEIVER"
-#define PROGVERS               "3.3.1-devmc"
 #define VERSION_1               0x33
 #define VERSION_2               0x1d
 
 #ifdef CMP_CC1101
+
 	#ifdef ARDUINO_AVR_ICT_BOARDS_ICT_BOARDS_AVR_RADINOCC1101
 		#define PIN_LED               13
 		#define PIN_SEND              9   // gdo0Pin TX out

--- a/__vm/.SIGNALDuino.vsarduino.h
+++ b/__vm/.SIGNALDuino.vsarduino.h
@@ -5,7 +5,7 @@
 			all non-arduino files created by visual micro and all visual studio project or solution files can be freely deleted and are not required to compile a sketch (do not delete your own code!).
 			note: debugger breakpoints are stored in '.sln' or '.asln' files, knowledge of last uploaded breakpoints is stored in the upload.vmps.xml file. Both files are required to continue a previous debug session without needing to compile and upload again
 	
-	Hardware: Arduino Pro or Pro Mini w/ ATmega328 (3.3V, 8 MHz), Platform=avr, Package=arduino
+	Hardware: Arduino Pro or Pro Mini w/ ATmega328 (5V, 16 MHz), Platform=avr, Package=arduino
 */
 
 #if defined(_VMICRO_INTELLISENSE)
@@ -14,7 +14,7 @@
 #define _VSARDUINO_H_
 #define __AVR_ATmega328p__
 #define __AVR_ATmega328P__
-#define F_CPU 8000000L
+#define F_CPU 16000000L
 #define ARDUINO 10803
 #define ARDUINO_AVR_PRO
 #define ARDUINO_ARCH_AVR

--- a/src/_micro-api/libraries/signalDecoder/src/signalDecoder.cpp
+++ b/src/_micro-api/libraries/signalDecoder/src/signalDecoder.cpp
@@ -66,7 +66,12 @@ inline void SignalDetectorClass::addData(const uint8_t value)
 		messageLen++;
 	}
 	else {
-		MSG_PRINTLN(F("addData overflow!!"));
+		MSG_PRINT("val="); MSG_PRINT(value);
+		MSG_PRINT(" msglen="); MSG_PRINT(messageLen);
+		MSG_PRINT(" bytecnt="); MSG_PRINT(message.bytecount); 
+		MSG_PRINT(" valcnt="); MSG_PRINT(message.valcount);
+		MSG_PRINT(" mTrunc="); MSG_PRINT(m_truncated);
+		MSG_PRINTLN(F(" addData overflow!!"));
 	}
 }
 


### PR DESCRIPTION
Den angepassten MC Decoder in den Branch cc1101 überführen.

Offen ist noch ein Fehler, der für eine fehlerhafte Erkennung der Polarität sorgt. Dieser tritt im Zusammenhang mit Wiederholungen auf.