### PR TITLE
Fixes for compiling in Arduino IDE

### DIFF
--- a/src/_micro-api/libraries/SimpleFIFO/library.properties
+++ b/src/_micro-api/libraries/SimpleFIFO/library.properties
@@ -1,4 +1,5 @@
-name=SimpleFIFOversion=1.0.0
+name=SimpleFIFO
+version=1.0.0
 author=Visual Micro
 maintainer=Visual Micro
 sentence=SimpleFIFO library code

--- a/src/_micro-api/libraries/TimerOne/library.properties
+++ b/src/_micro-api/libraries/TimerOne/library.properties
@@ -1,4 +1,5 @@
-name=TimerOne=1.0.0
+name=TimerOne
+version=1.0.0
 author=Arduino
 maintainer=Arduino
 sentence=TimerOne library code

--- a/src/_micro-api/libraries/output/library.properties
+++ b/src/_micro-api/libraries/output/library.properties
@@ -1,4 +1,5 @@
-name=outputversion=1.0.0
+name=output
+version=1.0.0
 author=Visual Micro
 maintainer=Visual Micro
 sentence=output library code

--- a/src/_micro-api/libraries/output/src/output.h
+++ b/src/_micro-api/libraries/output/src/output.h
@@ -4,7 +4,7 @@
 #define _OUTPUT_h
 
 #if defined(ARDUINO) && ARDUINO >= 100
-	#include "arduino.h"
+	#include "Arduino.h"
 #else
 	#include "WProgram.h"
 #endif

--- a/src/_micro-api/libraries/signalDecoder/library.properties
+++ b/src/_micro-api/libraries/signalDecoder/library.properties
@@ -1,8 +1,8 @@
-name=bitstore
+name=signalDecoder
 version=1.0.0
 author=Visual Micro
 maintainer=Visual Micro
-sentence=bitstore library code
+sentence=output library code
 paragraph=
 category=Uncategorized
 url=http://www.visualmicro.com

--- a/src/_micro-api/libraries/signalDecoder/src/signalDecoder.h
+++ b/src/_micro-api/libraries/signalDecoder/src/signalDecoder.h
@@ -33,7 +33,7 @@
 #define _SIGNALDECODER_h
 
 #if defined(ARDUINO) && ARDUINO >= 100
-	#include "arduino.h"
+	#include "Arduino.h"
 #else
 	#include "WProgram.h"
 #endif


### PR DESCRIPTION
Should fix #42.
The Arduino IDE need a library.properties for every library. Also the include files are case-sensitive (at least on linux).