### PR TITLE
CC110x/CC111x OOK/ASK Register Settings

### DIFF
--- a/SIGNALDuino.ino
+++ b/SIGNALDuino.ino
@@ -57,7 +57,7 @@
 
 
 
-#define PROGVERS               "3.3.1-RC10"
+#define PROGVERS               "3.3.1-RC-X-171218"
 #define PROGNAME               "RF_RECEIVER"
 #define VERSION_1               0x33
 #define VERSION_2               0x1d

--- a/cc1101.h
+++ b/cc1101.h
@@ -100,7 +100,8 @@ namespace cc1101 {
 		0x0D, // 00 IOCFG2    29     GDO2 as serial output
 		0x2E, // 01 IOCFG1           Tri-State
 		0x2D, // 02 IOCFG0    3F     GDO0 for input
-		0x07, // 03 FIFOTHR   
+		//0x07, // 03 FIFOTHR          RX filter bandwidth > 325 kHz, FIFOTHR = 0x07
+		0x47, // 03 FIFOTHR          RX filter bandwidth = 325 kHz, FIFOTHR = 0x47
 		0xD3, // 04 SYNC1     
 		0x91, // 05 SYNC0     
 		0x3D, // 06 PKTLEN    0F
@@ -126,11 +127,13 @@ namespace cc1101 {
 		0x6C, // 1A BSCFG
 		0x07, // 1B AGCCTRL2  03     42 dB instead of 33dB
 		0x00, // 1C AGCCTRL1  40     
-		0x90, // 1D AGCCTRL0  91     4dB decision boundery
+		//0x90, // 1D AGCCTRL0  90     4dB decision boundery
+    0x91, // 1D AGCCTRL0  91     8dB decision boundery
 		0x87, // 1E WOREVT1
 		0x6B, // 1F WOREVT0
 		0xF8, // 20 WORCTRL
-		0x56, // 21 FREND1
+		//0x56, // 21 FREND1    56     RX filter bandwidth = 101 kHz, FREND1 = 0x56
+		0xB6, // 21 FREND1    B6     RX filter bandwidth > 101 kHz, FREND1 = 0xB6
 		0x11, // 22 FREND0    16     0x11 for no PA ramping
 		0xE9, // 23 FSCAL3    A9    E9 ?? 
 		0x2A, // 24 FSCAL2    0A    

--- a/commands.h
+++ b/commands.h
@@ -256,7 +256,7 @@ namespace commands {
 					// RX filter bandwidth > 101 kHz, FREND1 = 0xB6
 					// RX filter bandwidth <= 101 kHz, FREND1 = 0x56
 					if (val >= 0xC7) {    // 199 = 0xC7 = 101 kHz
-					val = 0x57;          // FREND1 = 0x56
+					val = 0x56;          // FREND1 = 0x56
 					} else {
 						val = 0xB6;         // FREND1 = 0xB6
 					}

--- a/commands.h
+++ b/commands.h
@@ -250,6 +250,35 @@ namespace commands {
 				if (hasCC1101) {
 					cc1101::writeCCreg(reg, val);
 				}
+
+        if (reg == 18) {       // bwidth
+          reg = 35;            // 0x21 FREND1 (EEPROM-Addresse + 2)
+          // RX filter bandwidth > 101 kHz, FREND1 = 0xB6
+          // RX filter bandwidth <= 101 kHz, FREND1 = 0x56
+          if (val >= 199) {    // 199 = 0xC7 = 101 kHz
+            val = 86;          // FREND1 = 0x56
+          } else {
+            val = 182;         // FREND1 = 0xB6
+          }
+          EEPROM.write(reg, val);  
+          if (hasCC1101) {
+            cc1101::writeCCreg(reg, val);
+          }
+          reg = 5;             // 0x03 FIFOTHR (EEPROM-Addresse + 2)
+          memcpy(b, &IB_1[3], 2);
+          val = strtol(b, nullptr, 16);
+          // RX filter bandwidth > 325 kHz, FIFOTHR = 0x07
+          // RX filter bandwidth <= 325 kHz, FIFOTHR = 0x47
+          if (val >= 87) {     // 87 = 0x57 = 325 kHz
+            val = 71;          // FIFOTHR = 0x47
+          } else {
+            val = 7;           // FIFOTHR = 0x07
+          }
+          EEPROM.write(reg, val);  
+          if (hasCC1101) {
+            cc1101::writeCCreg(reg, val);
+          }
+        }
 			}
 			break;
 		default:

--- a/commands.h
+++ b/commands.h
@@ -251,34 +251,34 @@ namespace commands {
 					cc1101::writeCCreg(reg, val);
 				}
 
-        if (reg == 18) {       // bwidth
-          reg = 35;            // 0x21 FREND1 (EEPROM-Addresse + 2)
-          // RX filter bandwidth > 101 kHz, FREND1 = 0xB6
-          // RX filter bandwidth <= 101 kHz, FREND1 = 0x56
-          if (val >= 199) {    // 199 = 0xC7 = 101 kHz
-            val = 86;          // FREND1 = 0x56
-          } else {
-            val = 182;         // FREND1 = 0xB6
-          }
-          EEPROM.write(reg, val);  
-          if (hasCC1101) {
-            cc1101::writeCCreg(reg, val);
-          }
-          reg = 5;             // 0x03 FIFOTHR (EEPROM-Addresse + 2)
-          memcpy(b, &IB_1[3], 2);
-          val = strtol(b, nullptr, 16);
-          // RX filter bandwidth > 325 kHz, FIFOTHR = 0x07
-          // RX filter bandwidth <= 325 kHz, FIFOTHR = 0x47
-          if (val >= 87) {     // 87 = 0x57 = 325 kHz
-            val = 71;          // FIFOTHR = 0x47
-          } else {
-            val = 7;           // FIFOTHR = 0x07
-          }
-          EEPROM.write(reg, val);  
-          if (hasCC1101) {
-            cc1101::writeCCreg(reg, val);
-          }
-        }
+				if (reg == 18) {       // bwidth 0x12
+					reg = 0x21+2;            // 0x21 FREND1 (EEPROM-Addresse + 2)
+					// RX filter bandwidth > 101 kHz, FREND1 = 0xB6
+					// RX filter bandwidth <= 101 kHz, FREND1 = 0x56
+					if (val >= 0xC7) {    // 199 = 0xC7 = 101 kHz
+					val = 0x57;          // FREND1 = 0x56
+					} else {
+						val = 0xB6;         // FREND1 = 0xB6
+					}
+					EEPROM.write(reg, val);  
+					if (hasCC1101) {
+						cc1101::writeCCreg(reg, val);
+					}
+					reg = 0x03+2;             // 0x03 FIFOTHR (EEPROM-Addresse + 2)
+					memcpy(b, &IB_1[3], 2);
+					val = strtol(b, nullptr, 16);
+					// RX filter bandwidth > 325 kHz, FIFOTHR = 0x07
+					// RX filter bandwidth <= 325 kHz, FIFOTHR = 0x47
+					if (val >= 0x57) {     // 87 = 0x57 = 325 kHz
+						val = 0x47;          // FIFOTHR = 0x47
+					} else {
+						val = 0x07;           // FIFOTHR = 0x07
+					}
+					EEPROM.write(reg, val);  
+					if (hasCC1101) {
+						cc1101::writeCCreg(reg, val);
+					}
+				}
 			}
 			break;
 		default:

--- a/commands.h
+++ b/commands.h
@@ -251,7 +251,7 @@ namespace commands {
 					cc1101::writeCCreg(reg, val);
 				}
 
-				if (reg == 18) {       // bwidth 0x12
+				if (reg == 0x10+2) {       // 0x10 MDMCFG4 bwidth 325 kHz (EEPROM-Addresse + 2)
 					reg = 0x21+2;            // 0x21 FREND1 (EEPROM-Addresse + 2)
 					// RX filter bandwidth > 101 kHz, FREND1 = 0xB6
 					// RX filter bandwidth <= 101 kHz, FREND1 = 0x56


### PR DESCRIPTION
Better reception by adjusting the CC110x/CC111x OOK/ASK register settings (see TI Design Note DN022). This design note provides guidelines for finding optimum register settings for OOK/ASK operation.