### PR TITLE
Implement a Wifi reconnect event to restart the telnet server

### DIFF
--- a/SIGNALESP.ino
+++ b/SIGNALESP.ino
@@ -135,10 +135,11 @@ WiFiEventHandler gotIpEventHandler, disconnectedEventHandler;
 void setup() {
 	char cfg_ipmode[7] = "dhcp";
 
+	Server.setNoDelay(true);
 #ifdef ESP8266
 	gotIpEventHandler = WiFi.onStationModeGotIP([](const WiFiEventStationModeGotIP& event)
 	{
-		Server.stop();
+		//Server.stop();
 		Server.begin();  // start telnet server
 	});
 #else if defined(ESP32)
@@ -150,6 +151,7 @@ void setup() {
 	}, WiFiEvent_t::SYSTEM_EVENT_STA_DISCONNECTED);
 	*/
 #endif
+
 
 	//ESP.wdtEnable(2000);
 
@@ -389,7 +391,6 @@ void setup() {
 	os_timer_setfn(&cronTimer, &cronjob, 0);
 #endif
 
-	Server.setNoDelay(true);
 	musterDec.setStreamCallback(writeCallback);
 #ifdef CMP_CC1101
 	if (!hasCC1101 || cc1101::regCheck()) {

--- a/SIGNALESP.ino
+++ b/SIGNALESP.ino
@@ -135,6 +135,21 @@ WiFiEventHandler gotIpEventHandler, disconnectedEventHandler;
 void setup() {
 	char cfg_ipmode[7] = "dhcp";
 
+#ifdef ESP8266
+	gotIpEventHandler = WiFi.onStationModeGotIP([](const WiFiEventStationModeGotIP& event)
+	{
+		Server.stop();
+		Server.begin();  // start telnet server
+	});
+#else if defined(ESP32)
+	// TODO: Check why this can't be compiled
+	/*
+	WiFiEventId_t eventID = WiFi.onEvent([](WiFiEvent_t event, WiFiEventInfo_t    info) {
+		Serial.print("WiFi lost connection. Reason: ");
+		Serial.println(info.d;
+	}, WiFiEvent_t::SYSTEM_EVENT_STA_DISCONNECTED);
+	*/
+#endif
 
 	//ESP.wdtEnable(2000);
 
@@ -404,21 +419,6 @@ void setup() {
 #endif
 	pinAsOutput(PIN_SEND);
 	digitalLow(PIN_LED);
-#ifdef ESP8266
-	gotIpEventHandler = WiFi.onStationModeGotIP([](const WiFiEventStationModeGotIP& event)
-	{
-		Server.stop();
-		Server.begin();  // start telnet server
-	});
-#else if defined(ESP32)
-	// TODO: Check why this can't be compiled
-	/*
-	WiFiEventId_t eventID = WiFi.onEvent([](WiFiEvent_t event, WiFiEventInfo_t    info) {
-		Serial.print("WiFi lost connection. Reason: ");
-		Serial.println(info.d;
-	}, WiFiEvent_t::SYSTEM_EVENT_STA_DISCONNECTED);
-	*/
-#endif
 }
 
 void ICACHE_RAM_ATTR cronjob(void *pArg) {


### PR DESCRIPTION
After a WIFI reconnect, the server wasn't restarted, so no tcp connection was possible to the esp.


ESP was not allowed anymore to connect to SSID.
```
p:10.2.11.41,mask:255.255.255.0,gw:10.2.11.1
*WM: [2] Connection result: WL_CONNECTED
*WM: [3] lastconxresult: WL_CONNECTED
*WM: [1] AutoConnect: SUCCESS 
*WM: [1] STA IP Address: 10.2.11.41
*WM: [1] Starting Web Portal 
*WM: [3] dns server started with ip: 
*WM: [2] HTTP server started 
scandone
*WM: [2] WiFi Scan completed in 1590 ms
pm open,type:2 0
state: 5 -> 2 (1a0)
scandone
state: 0 -> 2 (b0)
state: 2 -> 0 (0)
reconnect
scandone
state: 0 -> 2 (b0)
state: 2 -> 0 (0)
reconnect
scandone
state: 0 -> 2 (b0)
state: 2 -> 0 (0)
reconnect
scandone
state: 0 -> 2 (b0)
state: 2 -> 0 (0)
reconnect
scandone
state: 0 -> 2 (b0)
state: 2 -> 3 (0)
state: 3 -> 5 (10)
add 0
aid 11
cnt `
```
Keepalive process notices this and tries reset command:
```
2019.12.04 22:40:19.241 4: IP: 10.2.11.41 -> 10.2.11.41
2019.12.04 22:40:19.238 5: HttpUtils url=http://10.2.11.41:23/
2019.12.04 22:39:12.060 4: IP: 10.2.11.41 -> 10.2.11.41
2019.12.04 22:39:12.059 5: HttpUtils url=http://10.2.11.41:23/
2019.12.04 22:38:09.150 4: IP: 10.2.11.41 -> 10.2.11.41
2019.12.04 22:38:09.148 5: HttpUtils url=http://10.2.11.41:23/
2019.12.04 22:37:03.450 4: IP: 10.2.11.41 -> 10.2.11.41
2019.12.04 22:37:03.449 5: HttpUtils url=http://10.2.11.41:23/
2019.12.04 22:36:00.476 4: IP: 10.2.11.41 -> 10.2.11.41
2019.12.04 22:36:00.475 5: HttpUtils url=http://10.2.11.41:23/
2019.12.04 22:34:58.909 3: ipDuino: 10.2.11.41: No route to host (113)
2019.12.04 22:34:58.909 1: ipDuino: Can't connect to 10.2.11.41:23: 10.2.11.41: No route to host (113)
2019.12.04 22:34:58.901 1: ipDuino: Can't connect to 10.2.11.41:23: No such file or directory
2019.12.04 22:34:58.900 4: HttpUtils: 10.2.11.41: No route to host (113)
2019.12.04 22:34:56.993 4: IP: 10.2.11.41 -> 10.2.11.41
2019.12.04 22:34:56.992 5: HttpUtils url=http://10.2.11.41:23/
2019.12.04 22:34:56.991 3: Opening ipDuino device 10.2.11.41:23
2019.12.04 22:34:56.989 3: ipDuino/reset: ESP8266cc1101
2019.12.04 22:34:56.988 3: ipDuino/keepalive not ok, retry count reached. Reset
2019.12.04 22:33:57.402 4: ipDuino/HandleWriteQueue: nothing to send, stopping timer
2019.12.04 22:33:57.087 5: ipDuino SW: P
2019.12.04 22:33:56.983 5: AddSendQueue: ipDuino: P (1)
2019.12.04 22:33:56.982 3: ipDuino/KeepAlive not ok, retry = 3 -> get ping
2019.12.04 22:32:57.397 4: ipDuino/HandleWriteQueue: nothing to send, stopping timer
2019.12.04 22:32:57.081 5: ipDuino SW: P
2019.12.04 22:32:56.976 5: AddSendQueue: ipDuino: P (1)
2019.12.04 22:32:56.975 3: ipDuino/KeepAlive not ok, retry = 2 -> get ping
2019.12.04 22:31:57.387 4: ipDuino/HandleWriteQueue: nothing to send, stopping timer
2019.12.04 22:31:57.072 5: ipDuino SW: P
2019.12.04 22:31:56.967 5: AddSendQueue: ipDuino: P (1)
2019.12.04 22:31:56.963 4: ipDuino/KeepAlive not ok, retry = 1 -> get ping
2019.12.04 22:30:56.952 4: ipDuino/keepalive ok, retry = 0
```

After reallowing the esp to connect to the SSID it get's new IP Address:
```
connected with xxxxxxx, channel 13
dhcp client start...
ip:10.2.11.41,mask:255.255.255.0,gw:10.2.11.1
pm open,type:2 0
```
And after a minute the module reconnects
```
2019.12.04 22:41:23.805 5: ipDuino SW: XQ
2019.12.04 22:41:23.804 3: ipDuino/init: disable receiver (XQ)
2019.12.04 22:41:22.302 1: 10.2.11.41:23 reappeared (ipDuino)
2019.12.04 22:41:22.301 1: ipDuino/init: 10.2.11.41:23
2019.12.04 22:41:22.300 1: ipDuino/define: 10.2.11.41:23
2019.12.04 22:41:22.253 4: IP: 10.2.11.41 -> 10.2.11.41
2019.12.04 22:41:22.251 5: HttpUtils url=http://10.2.11.41:23/
```