### PR TITLE
fix, compile with debug on some devices

### DIFF
--- a/src/cc1101.cpp
+++ b/src/cc1101.cpp
@@ -334,7 +334,7 @@ bool cc1101::regCheck()
 {
 	//char b[3];
 	//uint8_t val;
-	
+#ifdef CMP_CC1101
 	DBG_PRINT(FPSTR(TXT_CC1101));
 	DBG_PRINT(F("_PKTCTRL0=")); DBG_PRINT(readReg(CC1101_PKTCTRL0, CC1101_CONFIG));
 	DBG_PRINT(F(" vs initval PKTCTRL0=")); DBG_PRINTLN(cc1101::initVal[CC1101_PKTCTRL0]);
@@ -368,6 +368,7 @@ bool cc1101::regCheck()
 	DBG_PRINTLN(b);
 	*/
 	return (readReg(CC1101_PKTCTRL0, CC1101_CONFIG) == cc1101::initVal[CC1101_PKTCTRL0]) && (readReg(CC1101_IOCFG2, CC1101_CONFIG) == cc1101::initVal[CC1101_IOCFG2]);
+ #endif
 }
 
 
@@ -392,7 +393,7 @@ void cc1101::ccFactoryReset() {
 }
 
 void cc1101::CCinit(void) {  // initialize CC1101
-	
+#ifdef CMP_CC1101
 	DBG_PRINT(FPSTR(TXT_CCINIT)); 
 
 	cc1101_Deselect();                                  // some deselect and selects to init the cc1101
@@ -428,4 +429,6 @@ void cc1101::CCinit(void) {  // initialize CC1101
 
 	delay(1);
 	setReceiveMode();
+
+#endif
 }

--- a/src/signalduino.h
+++ b/src/signalduino.h
@@ -35,7 +35,7 @@
 #include "compile_config.h"
 
 
-#define PROGVERS               "3.4.0-dev+20200411"
+#define PROGVERS               "3.4.0-dev+20200612"
 #define VERSION_1               0x33
 #define VERSION_2               0x1d
 

--- a/src/signalduino.h
+++ b/src/signalduino.h
@@ -35,7 +35,7 @@
 #include "compile_config.h"
 
 
-#define PROGVERS               "3.4.0-dev+20200612"
+#define PROGVERS               "3.4.0-dev+20200611"
 #define VERSION_1               0x33
 #define VERSION_2               0x1d
 


### PR DESCRIPTION
ARDUINO IDE
- no compile Arduino nano, promini, esp8266 without cc1101 but with DEBUG flag

Options:

```
// Config flags for compiling correct options / boards Define only one!
//#define CMP_CC1101
//#define ARDUINO_ATMEGA328P_MINICUL 1
//#define ARDUINO_AVR_ICT_BOARDS_ICT_BOARDS_AVR_RADINOCC1101 1;
//#define OTHER_BOARD_WITH_CC1101  1


//Enable debug option here:
#define DEBUG
```


PlatformIO
- no compile Arduino nano, promini, esp8266 without cc1101 but with DEBUG flag

```
Environment                 Status    Duration
--------------------------  --------  ------------
nanoCC1101@debug            SUCCESS   00:00:09.021
nanoCC1101                  SUCCESS   00:00:07.231
nano328@debug               FAILED    00:00:02.310    <---------
nano328                     SUCCESS   00:00:06.817
miniculcc1101@debug         SUCCESS   00:00:07.196
miniculcc1101               SUCCESS   00:00:07.258
promini@debug               FAILED    00:00:02.219    <---------
promini                     SUCCESS   00:00:06.799
esp32dev                    SUCCESS   00:00:32.830
esp8266cc1101@latest        SUCCESS   00:00:24.455
esp8266cc1101@latest-debug  SUCCESS   00:00:23.858
esp8266@latest              SUCCESS   00:00:24.626
esp8266@latest-debug        FAILED    00:00:04.738    <---------

```



---------------------------------------------
**after revised code / after this PR**

ARDUINO IDE
- no ERROR

PlatformIO
- no ERROR

```
Environment                 Status    Duration
--------------------------  --------  ------------
nanoCC1101@debug            SUCCESS   00:00:03.583
nanoCC1101                  SUCCESS   00:00:03.362
nano328@debug               SUCCESS   00:00:06.584
nano328                     SUCCESS   00:00:03.592
miniculcc1101@debug         SUCCESS   00:00:03.724
miniculcc1101               SUCCESS   00:00:03.444
promini@debug               SUCCESS   00:00:06.137
promini                     SUCCESS   00:00:03.562
esp32dev                    SUCCESS   00:00:09.633
esp8266cc1101@latest        SUCCESS   00:00:02.971
esp8266cc1101@latest-debug  SUCCESS   00:00:04.306
esp8266@latest              SUCCESS   00:00:04.195
esp8266@latest-debug        SUCCESS   00:00:24.921
```