### PR TITLE
fix - strobe commands register

### DIFF
--- a/src/cc1101.cpp
+++ b/src/cc1101.cpp
@@ -194,7 +194,7 @@ void cc1101::commandStrobes(void) {
 	uint8_t val1;
 
 	if (isHexadecimalDigit(IB_1[3])) {
-		reg = (uint8_t)strtol(&IB_1[3], nullptr, 16);
+		reg = (uint8_t)strtol(&IB_1[3], nullptr, 16) + 0x30; // to strobe registers
 		if (reg < 0x3e) {
 			val = cmdStrobe(reg);
 			delay(1);

--- a/src/cc1101.cpp
+++ b/src/cc1101.cpp
@@ -194,7 +194,7 @@ void cc1101::commandStrobes(void) {
 	uint8_t val1;
 
 	if (isHexadecimalDigit(IB_1[3])) {
-	reg = (uint8_t)strtol(&IB_1[2], nullptr, 16);  // address strobe command | CC1101 - Table 42: Command Strobes
+		reg = (uint8_t)strtol(&IB_1[2], nullptr, 16);  // address strobe command | CC1101 - Table 42: Command Strobes
 		if (reg < 0x3E) {
 			val = cmdStrobe(reg);
 			delay(1);

--- a/src/cc1101.cpp
+++ b/src/cc1101.cpp
@@ -194,8 +194,8 @@ void cc1101::commandStrobes(void) {
 	uint8_t val1;
 
 	if (isHexadecimalDigit(IB_1[3])) {
-		reg = (uint8_t)strtol(&IB_1[3], nullptr, 16) + 0x30; // to strobe registers
-		if (reg < 0x3e) {
+	reg = (uint8_t)strtol(&IB_1[2], nullptr, 16);  // address strobe command | CC1101 - Table 42: Command Strobes
+		if (reg < 0x3E) {
 			val = cmdStrobe(reg);
 			delay(1);
 			val1 = cmdStrobe(0x3D);        //  No operation. May be used to get access to the chip status byte.

--- a/src/compile_config.h
+++ b/src/compile_config.h
@@ -18,7 +18,7 @@
 
 */
 
-#define PROGVERS               "3.4.0-dev_20200629"
+#define PROGVERS               "3.4.0-dev_20200707"
 
 #ifdef OTHER_BOARD_WITH_CC1101
 	#define CMP_CC1101


### PR DESCRIPTION
@elektron-bbs und ich haben etwas gefunden ;-)

send strobe command wrong, we need adress 0x3[0-D] not only one last [0-D]

view PDF site Table 42: Command Strobes

- without fix
wrong
cmdStrobeReg 06 chipStatus 01 delay1 01
cmdStrobeReg 04 chipStatus 01 delay1 01

- with fix
rigth
cmdStrobeReg 36 chipStatus 01 delay1 00
cmdStrobeReg 34 chipStatus 00 delay1 01
