### PR TITLE
sketch optimized for hardware with little flash

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -78,8 +78,8 @@ build_flags=
 
 [env:esp32_CC1101@debug]
 ; Espressif ESP32 - dual core, max 240 MHz, GPIO 36, power consumption 260 mA
-; RAM:   [=         ]  12.8% (used 41792 bytes from 327680 bytes)
-; Flash: [======    ]  64.2% (used 840934 bytes from 1310720 bytes)
+; RAM:   [=         ]  12.8% (used 41912 bytes from 327680 bytes)
+; Flash: [======    ]  64.2% (used 841290 bytes from 1310720 bytes)
 platform = espressif32
 board = nodemcu-32s
 framework = arduino
@@ -90,8 +90,8 @@ build_flags=-D DEBUG -D OTHER_BOARD_WITH_CC1101=1
 
 [env:esp32_CC1101]
 ; Espressif ESP32 - dual core, max 240 MHz, GPIO 36, power consumption 260 mA
-; RAM:   [=         ]  12.8% (used 41792 bytes from 327680 bytes)
-; Flash: [======    ]  63.9% (used 837846 bytes from 1310720 bytes)
+; RAM:   [=         ]  12.8% (used 41912 bytes from 327680 bytes)
+; Flash: [======    ]  63.9% (used 838154 bytes from 1310720 bytes)
 platform = espressif32
 board = nodemcu-32s
 framework = arduino
@@ -102,8 +102,8 @@ build_flags=-D OTHER_BOARD_WITH_CC1101=1
 
 [env:esp32@debug]
 ; Espressif ESP32 - dual core, max 240 MHz, GPIO 36, power consumption 260 mA
-; RAM:   [=         ]  12.7% (used 41672 bytes from 327680 bytes)
-; Flash: [======    ]  63.7% (used 834522 bytes from 1310720 bytes)
+; RAM:   [=         ]  12.8% (used 41792 bytes from 327680 bytes)
+; Flash: [======    ]  63.7% (used 834870 bytes from 1310720 bytes)
 platform = espressif32
 board = nodemcu-32s
 framework = arduino
@@ -115,8 +115,8 @@ build_flags=-D DEBUG
 
 [env:esp32]
 ; Espressif ESP32 - dual core, max 240 MHz, GPIO 36, power consumption 260 mA
-; RAM:   [=         ]  12.7% (used 41672 bytes from 327680 bytes)
-; Flash: [======    ]  63.5% (used 832150 bytes from 1310720 bytes)
+; RAM:   [=         ]  12.8% (used 41792 bytes from 327680 bytes)
+; Flash: [======    ]  63.5% (used 832450 bytes from 1310720 bytes)
 platform = espressif32
 board = nodemcu-32s
 framework = arduino
@@ -141,8 +141,8 @@ build_flags=
 
 [env:esp8266_CC1101@debug]
 ; Espressif ESP8266 - single core, max 160 MHz, GPIO 17, power consumption 80 mA
-; RAM:   [====      ]  39.3% (used 32180 bytes from 81920 bytes)
-; Flash: [====      ]  35.7% (used 373088 bytes from 1044464 bytes)
+; RAM:   [====      ]  39.4% (used 32260 bytes from 81920 bytes)
+; Flash: [====      ]  35.8% (used 373456 bytes from 1044464 bytes)
 platform = espressif8266
 board = nodemcuv2
 framework = arduino
@@ -155,8 +155,8 @@ build_flags=-D DEBUG -D OTHER_BOARD_WITH_CC1101=1
 
 [env:esp8266_CC1101]
 ; Espressif ESP8266 - single core, max 160 MHz, GPIO 17, power consumption 80 mA
-; RAM:   [====      ]  39.1% (used 31992 bytes from 81920 bytes)
-; Flash: [====      ]  35.4% (used 369700 bytes from 1044464 bytes)
+; RAM:   [====      ]  39.2% (used 32072 bytes from 81920 bytes)
+; Flash: [====      ]  35.4% (used 370084 bytes from 1044464 bytes)
 platform = espressif8266
 board = nodemcuv2
 framework = arduino
@@ -169,8 +169,8 @@ build_flags=-D OTHER_BOARD_WITH_CC1101=1
 
 [env:esp8266@debug]
 ; Espressif ESP8266 - single core, max 160 MHz, GPIO 17, power consumption 80 mA
-; RAM:   [====      ]  39.2% (used 32116 bytes from 81920 bytes)
-; Flash: [====      ]  35.1% (used 366908 bytes from 1044464 bytes)
+; RAM:   [====      ]  39.3% (used 32196 bytes from 81920 bytes)
+; Flash: [====      ]  35.2% (used 367292 bytes from 1044464 bytes)
 platform = espressif8266
 board = nodemcuv2
 framework = arduino
@@ -183,8 +183,8 @@ build_flags=-D DEBUG
 
 [env:esp8266]
 ; Espressif ESP8266 - single core, max 160 MHz, GPIO 17, power consumption 80 mA
-; RAM:   [====      ]  39.0% (used 31940 bytes from 81920 bytes)
-; Flash: [===       ]  34.9% (used 364332 bytes from 1044464 bytes)
+; RAM:   [====      ]  39.1% (used 32020 bytes from 81920 bytes)
+; Flash: [===       ]  34.9% (used 364700 bytes from 1044464 bytes)
 platform = espressif8266
 board = nodemcuv2
 framework = arduino
@@ -198,7 +198,7 @@ build_flags=
 [env:maple_mini_bootl_v1_CC1101@debug_wr]
 ; ST-Microelectronics STM32F103C8T6 bootloader v1.0
 ; RAM:   [====      ]  36.1% (used 6280 bytes from 17408 bytes)
-; Flash: [=====     ]  47.7% (used 52704 bytes from 110592 bytes)
+; Flash: [=====     ]  46.5% (used 51420 bytes from 110592 bytes)
 platform = ${env_maple_mini.platform}
 board = ${env_maple_mini.board}
 board_build.mcu = ${env_maple_mini.board_build.mcu}
@@ -214,7 +214,7 @@ build_flags = ${env_maple_mini.build_flags}
 [env:maple_mini_bootl_v1_CC1101@debug]
 ; ST-Microelectronics STM32F103C8T6 bootloader v1.0
 ; RAM:   [====      ]  36.0% (used 6272 bytes from 17408 bytes)
-; Flash: [=====     ]  47.0% (used 51944 bytes from 110592 bytes)
+; Flash: [=====     ]  45.8% (used 50660 bytes from 110592 bytes)
 platform = ${env_maple_mini.platform}
 board = ${env_maple_mini.board}
 board_build.mcu = ${env_maple_mini.board_build.mcu}
@@ -229,7 +229,7 @@ build_flags = ${env_maple_mini.build_flags}
 [env:maple_mini_bootl_v1_CC1101]
 ; ST-Microelectronics STM32F103C8T6 bootloader v1.0
 ; RAM:   [====      ]  36.0% (used 6272 bytes from 17408 bytes)
-; Flash: [====      ]  44.0% (used 48644 bytes from 110592 bytes)
+; Flash: [====      ]  42.8% (used 47376 bytes from 110592 bytes)
 platform = ${env_maple_mini.platform}
 board = ${env_maple_mini.board}
 board_build.mcu = ${env_maple_mini.board_build.mcu}
@@ -243,7 +243,7 @@ build_flags = ${env_maple_mini.build_flags}
 [env:maple_mini_bootl_v1]
 ; ST-Microelectronics STM32F103C8T6 bootloader v1.0
 ; RAM:   [====      ]  35.6% (used 6196 bytes from 17408 bytes)
-; Flash: [====      ]  39.1% (used 43296 bytes from 110592 bytes)
+; Flash: [====      ]  38.0% (used 42024 bytes from 110592 bytes)
 platform = ${env_maple_mini.platform}
 board = ${env_maple_mini.board}
 board_build.mcu = ${env_maple_mini.board_build.mcu}
@@ -256,7 +256,7 @@ build_flags = ${env_maple_mini.build_flags}
 [env:maple_mini_bootl_v2_CC1101@debug_wr]
 ; ST-Microelectronics STM32F103C8T6 bootloader v2.0
 ; RAM:   [==        ]  16.2% (used 3324 bytes from 20480 bytes)
-; Flash: [===       ]  34.9% (used 42900 bytes from 122880 bytes)
+; Flash: [===       ]  33.9% (used 41616 bytes from 122880 bytes)
 platform = ${env_maple_mini.platform}
 board = maple_mini_b20
 board_build.mcu = ${env_maple_mini.board_build.mcu}
@@ -269,7 +269,7 @@ build_flags=-D ARDUINO_MAPLEMINI_F103CB=1 -D OTHER_BOARD_WITH_CC1101=1 -D WATCHD
 [env:maple_mini_bootl_v2_CC1101@debug]
 ; ST-Microelectronics STM32F103C8T6 bootloader v2.0
 ; RAM:   [==        ]  16.2% (used 3316 bytes from 20480 bytes)
-; Flash: [===       ]  34.3% (used 42148 bytes from 122880 bytes)
+; Flash: [===       ]  33.3% (used 40864 bytes from 122880 bytes)
 platform = ${env_maple_mini.platform}
 board = maple_mini_b20
 board_build.mcu = ${env_maple_mini.board_build.mcu}
@@ -282,7 +282,7 @@ build_flags=-D ARDUINO_MAPLEMINI_F103CB=1 -D OTHER_BOARD_WITH_CC1101=1 -D DEBUG
 [env:maple_mini_bootl_v2_CC1101]
 ; ST-Microelectronics STM32F103C8T6 bootloader v2.0
 ; RAM:   [==        ]  16.2% (used 3316 bytes from 20480 bytes)
-; Flash: [===       ]  31.6% (used 38844 bytes from 122880 bytes)
+; Flash: [===       ]  30.6% (used 37572 bytes from 122880 bytes)
 platform = ${env_maple_mini.platform}
 board = maple_mini_b20
 board_build.mcu = ${env_maple_mini.board_build.mcu}
@@ -295,7 +295,7 @@ build_flags=-D ARDUINO_MAPLEMINI_F103CB=1 -D OTHER_BOARD_WITH_CC1101=1
 [env:maple_mini_bootl_v2]
 ; ST-Microelectronics STM32F103C8T6 bootloader v2.0
 ; RAM:   [==        ]  15.8% (used 3240 bytes from 20480 bytes)
-; Flash: [===       ]  27.3% (used 33516 bytes from 122880 bytes)
+; Flash: [===       ]  26.2% (used 32244 bytes from 122880 bytes)
 platform = ${env_maple_mini.platform}
 board = maple_mini_b20
 board_build.mcu = ${env_maple_mini.board_build.mcu}
@@ -307,8 +307,8 @@ build_flags=-D ARDUINO_MAPLEMINI_F103CB=1
 
 [env:nano_bootl_new_CC1101@debug]
 ; Arduino Nano ATmega328 - bootloader Optiboot
-; RAM:   [======    ]  56.3% (used 1153 bytes from 2048 bytes)
-; Flash: [========= ]  94.0% (used 28888 bytes from 30720 bytes)
+; RAM:   [=====     ]  54.2% (used 1109 bytes from 2048 bytes)
+; Flash: [========= ]  90.0% (used 27638 bytes from 30720 bytes)
 platform = atmelavr
 board = nanoatmega328new
 monitor_speed = 57600
@@ -319,8 +319,8 @@ build_flags=-D OTHER_BOARD_WITH_CC1101=1 -D DEBUG
 
 [env:nano_bootl_new_CC1101]
 ; Arduino Nano ATmega328 - bootloader Optiboot
-; RAM:   [=====     ]  47.0% (used 963 bytes from 2048 bytes)
-; Flash: [========  ]  84.9% (used 26068 bytes from 30720 bytes)
+; RAM:   [====      ]  45.0% (used 921 bytes from 2048 bytes)
+; Flash: [========  ]  80.8% (used 24820 bytes from 30720 bytes)
 platform = atmelavr
 board = nanoatmega328new
 monitor_speed = 57600
@@ -331,8 +331,8 @@ build_flags=-D OTHER_BOARD_WITH_CC1101=1
 
 [env:nano_bootl_new@debug]
 ; Arduino Nano ATmega328 - bootloader Optiboot
-; RAM:   [=====     ]  53.3% (used 1092 bytes from 2048 bytes)
-; Flash: [========  ]  81.3% (used 24972 bytes from 30720 bytes)
+; RAM:   [=====     ]  51.3% (used 1050 bytes from 2048 bytes)
+; Flash: [========  ]  77.2% (used 23724 bytes from 30720 bytes)
 platform = atmelavr
 board = nanoatmega328new
 monitor_speed = 57600
@@ -344,8 +344,8 @@ src_filter =-cc1101.h -cc1101.cpp +<*> -<.git/> -<.svn/> -<example/> -<examples/
 
 [env:nano_bootl_new]
 ; Arduino Nano ATmega328 - bootloader Optiboot
-; RAM:   [====      ]  44.1% (used 904 bytes from 2048 bytes)
-; Flash: [=======   ]  74.3% (used 22812 bytes from 30720 bytes)
+; RAM:   [====      ]  42.1% (used 862 bytes from 2048 bytes)
+; Flash: [=======   ]  70.2% (used 21564 bytes from 30720 bytes)
 platform = atmelavr
 board = nanoatmega328new
 monitor_speed = 57600
@@ -356,8 +356,8 @@ build_flags=
 
 [env:nano_bootl_old_CC1101@debug]
 ; Arduino Nano ATmega328 - bootloader ATmegaBOOT
-; RAM:   [======    ]  56.3% (used 1153 bytes from 2048 bytes)
-; Flash: [========= ]  94.0% (used 28888 bytes from 30720 bytes)
+; RAM:   [=====     ]  54.2% (used 1109 bytes from 2048 bytes)
+; Flash: [========= ]  90.0% (used 27638 bytes from 30720 bytes)
 platform = atmelavr
 board = nanoatmega328
 monitor_speed = 57600
@@ -368,8 +368,8 @@ build_flags=-D OTHER_BOARD_WITH_CC1101=1 -D DEBUG
 
 [env:nano_bootl_old_CC1101]
 ; Arduino Nano ATmega328 - bootloader ATmegaBOOT
-; RAM:   [=====     ]  47.0% (used 963 bytes from 2048 bytes)
-; Flash: [========  ]  84.9% (used 26068 bytes from 30720 bytes)
+; RAM:   [====      ]  45.0% (used 921 bytes from 2048 bytes)
+; Flash: [========  ]  80.8% (used 24820 bytes from 30720 bytes)
 platform = atmelavr
 board = nanoatmega328
 monitor_speed = 57600
@@ -380,8 +380,8 @@ build_flags=-D OTHER_BOARD_WITH_CC1101=1
 
 [env:nano_bootl_old@debug]
 ; Arduino Nano ATmega328 - bootloader ATmegaBOOT
-; RAM:   [=====     ]  53.3% (used 1092 bytes from 2048 bytes)
-; Flash: [========  ]  81.3% (used 24972 bytes from 30720 bytes)
+; RAM:   [=====     ]  51.3% (used 1050 bytes from 2048 bytes)
+; Flash: [========  ]  77.2% (used 23724 bytes from 30720 bytes)
 platform = atmelavr
 board = nanoatmega328
 monitor_speed = 57600
@@ -393,8 +393,8 @@ src_filter =-cc1101.h -cc1101.cpp +<*> -<.git/> -<.svn/> -<example/> -<examples/
 
 [env:nano_bootl_old]
 ; Arduino Nano ATmega328 - bootloader ATmegaBOOT
-; RAM:   [====      ]  44.1% (used 904 bytes from 2048 bytes)
-; Flash: [=======   ]  74.3% (used 22812 bytes from 30720 bytes)
+; RAM:   [====      ]  42.1% (used 862 bytes from 2048 bytes)
+; Flash: [=======   ]  70.2% (used 21564 bytes from 30720 bytes)
 platform = atmelavr
 board = nanoatmega328
 monitor_speed = 57600
@@ -405,8 +405,8 @@ build_flags=
 
 [env:pro_promini_16MHz_CC1101@debug]
 ; Arduino Pro or Pro Mini - Atmel ATmega328 running at 16MHz
-; RAM:   [======    ]  56.3% (used 1153 bytes from 2048 bytes)
-; Flash: [========= ]  94.0% (used 28888 bytes from 30720 bytes)
+; RAM:   [=====     ]  54.2% (used 1109 bytes from 2048 bytes)
+; Flash: [========= ]  90.0% (used 27638 bytes from 30720 bytes)
 platform = atmelavr
 board = pro16MHzatmega328
 monitor_speed = 57600
@@ -417,8 +417,8 @@ build_flags=-D OTHER_BOARD_WITH_CC1101=1 -D DEBUG
 
 [env:pro_promini_16MHz_CC1101]
 ; Arduino Pro or Pro Mini - Atmel ATmega328 running at 16MHz
-; RAM:   [=====     ]  47.0% (used 963 bytes from 2048 bytes)
-; Flash: [========  ]  84.9% (used 26068 bytes from 30720 bytes)
+; RAM:   [====      ]  45.0% (used 921 bytes from 2048 bytes)
+; Flash: [========  ]  80.8% (used 24820 bytes from 30720 bytes)
 platform = atmelavr
 board = pro16MHzatmega328
 monitor_speed = 57600
@@ -429,8 +429,8 @@ build_flags=-D OTHER_BOARD_WITH_CC1101=1
 
 [env:pro_promini_16MHz@debug]
 ; Arduino Pro or Pro Mini - Atmel ATmega328 running at 8MHz
-; RAM:   [=====     ]  53.3% (used 1092 bytes from 2048 bytes)
-; Flash: [========  ]  81.3% (used 24972 bytes from 30720 bytes)
+; RAM:   [=====     ]  51.3% (used 1050 bytes from 2048 bytes)
+; Flash: [========  ]  77.2% (used 23724 bytes from 30720 bytes)
 platform = atmelavr
 board = pro16MHzatmega328
 monitor_speed = 57600
@@ -441,8 +441,8 @@ build_flags=-D DEBUG
 
 [env:pro_promini_16MHz]
 ; Arduino Pro or Pro Mini - Atmel ATmega328 running at 16MHz
-; RAM:   [====      ]  44.1% (used 904 bytes from 2048 bytes)
-; Flash: [=======   ]  74.2% (used 22802 bytes from 30720 bytes)
+; RAM:   [====      ]  42.1% (used 862 bytes from 2048 bytes)
+; Flash: [=======   ]  70.2% (used 21554 bytes from 30720 bytes)
 platform = atmelavr
 board = pro8MHzatmega328
 monitor_speed = 57600
@@ -453,8 +453,8 @@ build_flags=
 
 [env:pro_promini_8MHz_CC1101@debug]
 ; Arduino Pro or Pro Mini - Atmel ATmega328 running at 8MHz
-; RAM:   [======    ]  56.3% (used 1153 bytes from 2048 bytes)
-; Flash: [========= ]  94.0% (used 28878 bytes from 30720 bytes)
+; RAM:   [=====     ]  53.8% (used 1101 bytes from 2048 bytes)
+; Flash: [========= ]  90.1% (used 27684 bytes from 30720 bytes)
 platform = atmelavr
 board = pro8MHzatmega328
 monitor_speed = 57600
@@ -465,8 +465,8 @@ build_flags=-D OTHER_BOARD_WITH_CC1101=1 -D DEBUG
 
 [env:pro_promini_8MHz_CC1101]
 ; Arduino Pro or Pro Mini - Atmel ATmega328 running at 8MHz
-; RAM:   [=====     ]  47.0% (used 963 bytes from 2048 bytes)
-; Flash: [========  ]  84.8% (used 26058 bytes from 30720 bytes)
+; RAM:   [====      ]  44.6% (used 913 bytes from 2048 bytes)
+; Flash: [========  ]  80.9% (used 24866 bytes from 30720 bytes)
 platform = atmelavr
 board = pro8MHzatmega328
 monitor_speed = 57600
@@ -477,8 +477,8 @@ build_flags=-D OTHER_BOARD_WITH_CC1101=1
 
 [env:pro_promini_8MHz@debug]
 ; Arduino Pro or Pro Mini - Atmel ATmega328 running at 8MHz
-; RAM:   [=====     ]  53.3% (used 1092 bytes from 2048 bytes)
-; Flash: [========  ]  81.3% (used 24962 bytes from 30720 bytes)
+; RAM:   [=====     ]  50.9% (used 1042 bytes from 2048 bytes)
+; Flash: [========  ]  77.4% (used 23768 bytes from 30720 bytes)
 platform = atmelavr
 board = pro8MHzatmega328
 monitor_speed = 57600
@@ -489,8 +489,8 @@ build_flags=-D DEBUG
 
 [env:pro_promini_8MHz]
 ; Arduino Pro or Pro Mini - Atmel ATmega328 running at 8MHz
-; RAM:   [====      ]  44.1% (used 904 bytes from 2048 bytes)
-; Flash: [=======   ]  74.2% (used 22802 bytes from 30720 bytes)
+; RAM:   [====      ]  41.7% (used 854 bytes from 2048 bytes)
+; Flash: [=======   ]  70.3% (used 21610 bytes from 30720 bytes)
 platform = atmelavr
 board = pro8MHzatmega328
 monitor_speed = 57600
@@ -501,8 +501,8 @@ build_flags=
 
 [env:radino_CC1101@debug]
 ; Arduino compatible (Arduino Micro / Leonardo) - Atmel ATmega32U4
-; RAM:   [====      ]  43.6% (used 1116 bytes from 2560 bytes)
-; Flash: [==========]  108.8% (used 31192 bytes from 28672 bytes)
+; RAM:   [===       ]  41.9% (used 1072 bytes from 2560 bytes)
+; Flash: [==========]  104.4% (used 29942 bytes from 28672 bytes)
 ;
 ; Radino board from in-circuit is not in POI
 ; these are compatible with all PIN´s
@@ -518,8 +518,8 @@ build_flags=-D ARDUINO_RADINOCC1101=1 -D DEBUG
 
 [env:radino_CC1101]
 ; Arduino compatible (Arduino Micro / Leonardo) - Atmel ATmega32U4
-; RAM:   [====      ]  36.1% (used 924 bytes from 2560 bytes)
-; Flash: [==========]  98.9% (used 28362 bytes from 28672 bytes)
+; RAM:   [===       ]  34.5% (used 882 bytes from 2560 bytes)
+; Flash: [========= ]  94.6% (used 27114 bytes from 28672 bytes)
 ;
 ; Radino board from in-circuit is not in POI
 ; these are compatible with all PIN´s
@@ -535,8 +535,8 @@ build_flags=-D ARDUINO_RADINOCC1101=1
 
 [env:wemos_d1_mini_pro_CC1101@debug]
 ; Espressif ESP8266 WeMos D1 mini pro - single core, max 160MHz, GPIO 11, power consumption 70 mA
-; RAM:   [====      ]  39.3% (used 32180 bytes from 81920 bytes)
-; Flash: [====      ]  35.7% (used 373088 bytes from 1044464 bytes)
+; RAM:   [====      ]  39.4% (used 32260 bytes from 81920 bytes)
+; Flash: [====      ]  35.8% (used 373456 bytes from 1044464 bytes)
 platform = espressif8266
 board = d1_mini_pro
 framework = arduino
@@ -547,8 +547,8 @@ build_flags=-D PIN_LED_INVERSE=1 -D OTHER_BOARD_WITH_CC1101=1 -D DEBUG
 
 [env:wemos_d1_mini_pro_CC1101]
 ; Espressif ESP8266 WeMos D1 mini pro - single core, max 160MHz, GPIO 11, power consumption 70 mA
-; RAM:   [====      ]  39.1% (used 31992 bytes from 81920 bytes)
-; Flash: [====      ]  35.4% (used 369700 bytes from 1044464 bytes)
+; RAM:   [====      ]  39.0% (used 31944 bytes from 81920 bytes)
+; Flash: [====      ]  35.4% (used 370212 bytes from 1044464 bytes)
 platform = espressif8266
 board = d1_mini_pro
 framework = arduino
@@ -559,8 +559,8 @@ build_flags=-D PIN_LED_INVERSE=1 -D OTHER_BOARD_WITH_CC1101=1
 
 [env:wemos_d1_mini_pro@debug]
 ; Espressif ESP8266 WeMos D1 mini pro - single core, max 160MHz, GPIO 11, power consumption 70 mA
-; RAM:   [====      ]  39.2% (used 32116 bytes from 81920 bytes)
-; Flash: [====      ]  35.1% (used 366908 bytes from 1044464 bytes)
+; RAM:   [====      ]  39.1% (used 32052 bytes from 81920 bytes)
+; Flash: [====      ]  35.2% (used 367404 bytes from 1044464 bytes)
 platform = espressif8266
 board = d1_mini_pro
 framework = arduino
@@ -571,8 +571,8 @@ build_flags=-D PIN_LED_INVERSE=1 -D DEBUG
 
 [env:wemos_d1_mini_pro]
 ; Espressif ESP8266 WeMos D1 mini pro - single core, max 160MHz, GPIO 11, power consumption 70 mA
-; RAM:   [====      ]  39.0% (used 31940 bytes from 81920 bytes)
-; Flash: [===       ]  34.9% (used 364332 bytes from 1044464 bytes)
+; RAM:   [====      ]  38.9% (used 31876 bytes from 81920 bytes)
+; Flash: [===       ]  34.9% (used 364828 bytes from 1044464 bytes)
 platform = espressif8266
 board = d1_mini_pro
 framework = arduino
@@ -586,8 +586,8 @@ build_flags=-D PIN_LED_INVERSE=1
 ; -----------------------------------------------------------
 
 [env:SDC@DEBUG_1]
-; RAM:   [====      ]  39.3% (used 32180 bytes from 81920 bytes)
-; Flash: [====      ]  35.7% (used 373088 bytes from 1044464 bytes)
+; RAM:   [====      ]  39.4% (used 32260 bytes from 81920 bytes)
+; Flash: [====      ]  35.8% (used 373456 bytes from 1044464 bytes)
 platform = espressif8266
 board = nodemcuv2
 framework = arduino
@@ -599,8 +599,8 @@ lib_deps =
 build_flags=-D OTHER_BOARD_WITH_CC1101=1 -D DEBUG=1
 
 [env:SDC@DEBUGDECODE_1]
-; RAM:   [====      ]  39.6% (used 32424 bytes from 81920 bytes)
-; Flash: [====      ]  35.9% (used 374700 bytes from 1044464 bytes)
+; RAM:   [====      ]  39.5% (used 32388 bytes from 81920 bytes)
+; Flash: [====      ]  35.9% (used 375224 bytes from 1044464 bytes)
 platform = espressif8266
 board = nodemcuv2
 framework = arduino
@@ -612,8 +612,8 @@ lib_deps =
 build_flags=-D OTHER_BOARD_WITH_CC1101=1 -D DEBUG -D DEBUGDECODE=1
 
 [env:SDC@DEBUGDECODE_255]
-; RAM:   [====      ]  39.7% (used 32500 bytes from 81920 bytes)
-; Flash: [====      ]  35.9% (used 374744 bytes from 1044464 bytes)
+; RAM:   [====      ]  39.6% (used 32452 bytes from 81920 bytes)
+; Flash: [====      ]  35.9% (used 375240 bytes from 1044464 bytes)
 platform = espressif8266
 board = nodemcuv2
 framework = arduino
@@ -625,8 +625,8 @@ lib_deps =
 build_flags=-D OTHER_BOARD_WITH_CC1101=1 -D DEBUG -D DEBUGDECODE=255
 
 [env:SDC@DEBUGDETECT_0]
-; RAM:   [====      ]  39.3% (used 32212 bytes from 81920 bytes)
-; Flash: [====      ]  35.7% (used 373232 bytes from 1044464 bytes)
+; RAM:   [====      ]  39.2% (used 32148 bytes from 81920 bytes)
+; Flash: [====      ]  35.8% (used 373728 bytes from 1044464 bytes)
 platform = espressif8266
 board = nodemcuv2
 framework = arduino
@@ -638,8 +638,8 @@ lib_deps =
 build_flags=-D OTHER_BOARD_WITH_CC1101=1 -D DEBUG=1 -D DEBUGDETECT=0
 
 [env:SDC@DEBUGDETECT_1]
-; RAM:   [====      ]  39.7% (used 32504 bytes from 81920 bytes)
-; Flash: [====      ]  35.8% (used 374116 bytes from 1044464 bytes)
+; RAM:   [====      ]  39.6% (used 32440 bytes from 81920 bytes)
+; Flash: [====      ]  35.9% (used 374596 bytes from 1044464 bytes)
 platform = espressif8266
 board = nodemcuv2
 framework = arduino
@@ -651,8 +651,8 @@ lib_deps =
 build_flags=-D OTHER_BOARD_WITH_CC1101=1 -D DEBUG=1 -D DEBUGDETECT=1
 
 [env:SDC@DEBUGDETECT_2]
-; RAM:   [====      ]  39.7% (used 32504 bytes from 81920 bytes)
-; Flash: [====      ]  35.8% (used 374172 bytes from 1044464 bytes)
+; RAM:   [====      ]  39.6% (used 32452 bytes from 81920 bytes)
+; Flash: [====      ]  35.9% (used 374648 bytes from 1044464 bytes)
 platform = espressif8266
 board = nodemcuv2
 framework = arduino
@@ -664,8 +664,8 @@ lib_deps =
 build_flags=-D OTHER_BOARD_WITH_CC1101=1 -D DEBUG=1 -D DEBUGDETECT=2
 
 [env:SDC@DEBUGDETECT_3]
-; RAM:   [====      ]  39.8% (used 32564 bytes from 81920 bytes)
-; Flash: [====      ]  35.9% (used 374632 bytes from 1044464 bytes)
+; RAM:   [====      ]  39.7% (used 32504 bytes from 81920 bytes)
+; Flash: [====      ]  35.9% (used 375124 bytes from 1044464 bytes)
 platform = espressif8266
 board = nodemcuv2
 framework = arduino
@@ -677,8 +677,8 @@ lib_deps =
 build_flags=-D OTHER_BOARD_WITH_CC1101=1 -D DEBUG=1 -D DEBUGDETECT=3
 
 [env:SDC@DEBUGDETECT_3_DEBUGDECODE_1]
-; RAM:   [====      ]  40.1% (used 32824 bytes from 81920 bytes)
-; Flash: [====      ]  36.0% (used 376228 bytes from 1044464 bytes)
+; RAM:   [====      ]  40.0% (used 32776 bytes from 81920 bytes)
+; Flash: [====      ]  36.1% (used 376764 bytes from 1044464 bytes)
 platform = espressif8266
 board = nodemcuv2
 framework = arduino
@@ -690,8 +690,8 @@ lib_deps =
 build_flags=-D OTHER_BOARD_WITH_CC1101=1 -D DEBUG -D DEBUGDETECT=3 -D DEBUGDECODE=1
 
 [env:SDC@DEBUGDETECT_255]
-; RAM:   [====      ]  39.9% (used 32692 bytes from 81920 bytes)
-; Flash: [====      ]  35.9% (used 375032 bytes from 1044464 bytes)
+; RAM:   [====      ]  39.8% (used 32644 bytes from 81920 bytes)
+; Flash: [====      ]  36.0% (used 375528 bytes from 1044464 bytes)
 platform = espressif8266
 board = nodemcuv2
 framework = arduino
@@ -703,8 +703,8 @@ lib_deps =
 build_flags=-D OTHER_BOARD_WITH_CC1101=1 -D DEBUG=1 -D DEBUGDETECT=255
 
 [env:SDC@DEBUGDETECT_255_DEBUGDECODE_1]
-; RAM:   [====      ]  40.2% (used 32932 bytes from 81920 bytes)
-; Flash: [====      ]  36.1% (used 376632 bytes from 1044464 bytes)
+; RAM:   [====      ]  40.1% (used 32884 bytes from 81920 bytes)
+; Flash: [====      ]  36.1% (used 377152 bytes from 1044464 bytes)
 platform = espressif8266
 board = nodemcuv2
 framework = arduino

--- a/src/_micro-api/libraries/signalDecoder/src/signalDecoder.cpp
+++ b/src/_micro-api/libraries/signalDecoder/src/signalDecoder.cpp
@@ -50,10 +50,10 @@
  */
 
 char* myitoa(int num, char *str) {
-  static const uint16_t pows10[] = {10000, 1000, 100, 10};
+  static const uint16_t pows10[4] = {10000, 1000, 100, 10};
   const uint16_t *p = pows10;
   uint16_t pow10;
-  uint8_t not0 = 0;
+  bool not0 = 0;
   uint8_t idx = 0;
   if (num < 0) {
     str[idx++] = '-';
@@ -508,7 +508,7 @@ void SignalDetectorClass::processMessage()
 					if (_rssiCallback != nullptr)
 					{
 						//␂Ms;��;��;���;��;D$$!!!###!#!#!!!!#!##!##!!##!!!!!!!!!!!!!!#!!␂;C2;S4;    RF1;    O;m2;␃
-						SDC_PRINT('R'); SDC_PRINTtoHEX(rssiValue); SDC_PRINT(';');
+						SDC_PRINT('R'); SDC_PRINT_intToHex(rssiValue); SDC_PRINT(';');
 					}
 				}
 				else {
@@ -770,7 +770,7 @@ MUOutput:
 					if (_rssiCallback != nullptr)
 					{
 						//␂Mu;���;�؁;���;���;���;�Å;���;�܅;D␁#$TgTTgggggggggggTgggT;C7;    R21;    ␃
-						SDC_PRINT('R'); SDC_PRINTtoHEX(rssiValue); SDC_PRINT(';');
+						SDC_PRINT('R'); SDC_PRINT_intToHex(rssiValue); SDC_PRINT(';');
 					}
 				}
 				else {
@@ -863,9 +863,9 @@ MUOutput:
 
 
 /* function to convert to HEX without a leading zero */
-void SignalDetectorClass::SDC_PRINTtoHEX(unsigned int numberToPrint) {  // smaller memory variant for sprintf hex output ( sprintf(buf, "R%X;", value) )
+void SignalDetectorClass::SDC_PRINT_intToHex(unsigned int numberToPrint) {  // smaller memory variant for sprintf hex output ( sprintf(buf, "R%X;", value) )
   if (numberToPrint >= 16)
-    SDC_PRINTtoHEX(numberToPrint / 16);
+    SDC_PRINT_intToHex(numberToPrint / 16);
   /* line is needed, no line - no output !!! */
   SDC_PRINT("0123456789ABCDEF"[numberToPrint % 16]);
 }

--- a/src/_micro-api/libraries/signalDecoder/src/signalDecoder.cpp
+++ b/src/_micro-api/libraries/signalDecoder/src/signalDecoder.cpp
@@ -43,6 +43,40 @@
 #endif
 
 
+
+/* **********************************************************
+ * SELFMADE - implementation of non standard function itoa()
+ * "itoa() function is not defined in ANSI-C and is not part of C++, but is supported by some compilers."
+ */
+
+char* myitoa(int num, char *str) {
+  static const uint16_t pows10[] = {10000, 1000, 100, 10};
+  const uint16_t *p = pows10;
+  uint16_t pow10;
+  uint8_t not0 = 0;
+  uint8_t idx = 0;
+  if (num < 0) {
+    str[idx++] = '-';
+    num = -num;
+  }
+  do {
+    char c = '0';
+    pow10 = *p++;
+    while ((uint16_t) num >= pow10) {
+      not0 = 1;
+      num -= pow10;
+      c++;
+    }
+    if (not0) str[idx++] = c;
+  } while (! (pow10 & 2)); // pow10 != 10
+  str[idx++] = num + '0';
+  str[idx++] = '\0';
+  return str;
+}
+
+/* END - SELFMADE implementation section */
+
+
 //Helper function to check buffer for bad data
 const bool SignalDetectorClass::checkMBuffer(const uint8_t begin)
 {
@@ -111,8 +145,7 @@ void SignalDetectorClass::addData(const int8_t value)
 		*/
 	} else {
 		printOut();
-		SDC_PRINT(" addData oflow->");
-		SDC_PRINT(" mstart="); SDC_PRINT(mstart);
+		SDC_PRINT(" addData oflow-> mstart="); SDC_PRINT(mstart);
 		SDC_PRINT(" mend="); SDC_PRINT(mend);
 	}
 	SDC_PRINT(" val="); SDC_PRINT(value);
@@ -469,26 +502,13 @@ void SignalDetectorClass::processMessage()
 						SDC_PRINT(n);
 					}
 
-					/* MR to search other Variant
-					SDC_PRINT(";C");
-					SDC_PRINT(clock, HEX);
-					SDC_PRINT(";S");
-					SDC_PRINT(sync, HEX);
-					SDC_PRINT(';');
-					*/
-
-					n = sprintf(buf, ";C%X;S%X;", clock, sync);
-					SDC_PRINT(buf);
+					//␂Ms;��;��;���;��;D$$!!!###!#!#!!!!#!##!##!!##!!!!!!!!!!!!!!#!!␂    ;C2;S4;    RF1;O;m2;␃
+					SDC_PRINT(";C"); SDC_PRINT(clock + 48); SDC_PRINT(";S"); SDC_PRINT(sync + 48); SDC_PRINT(';');
 
 					if (_rssiCallback != nullptr)
 					{
-						/* MR to search other Variant
-						SDC_PRINT('R');
-						SDC_PRINT(rssiValue, HEX);
-						SDC_PRINT(';');
-						*/
-						n = sprintf(buf, "R%X;", rssiValue);
-						SDC_PRINT(buf);
+						//␂Ms;��;��;���;��;D$$!!!###!#!#!!!!#!##!##!!##!!!!!!!!!!!!!!#!!␂;C2;S4;    RF1;    O;m2;␃
+						SDC_PRINT('R'); SDC_PRINTtoHEX(rssiValue); SDC_PRINT(';');
 					}
 				}
 				else {
@@ -497,59 +517,30 @@ void SignalDetectorClass::processMessage()
 					for (uint8_t idx = 0; idx < patternLen; idx++)
 					{
 						if (pattern[idx] == 0 || histo[idx] == 0) continue;
-						/* MR to search other Variant
-						SDC_PRINT('P');
-						SDC_PRINT(idx);
-						SDC_PRINT('=');
-						SDC_PRINT(pattern[idx]);
-						SDC_PRINT(';');
-						*/
-						
-						//SDC_PRINT('P'); SDC_PRINT(idx); SDC_PRINT('='); SDC_PRINT(itoa(pattern[idx], buf, 10)); SDC_PRINT(SERIAL_DELIMITER);
-						n = sprintf(buf, "P%i=%i;", idx,pattern[idx]);
-						SDC_PRINT(buf);
+						//␂MS;    P2=-14273;P3=371;P4=-1430;P5=1285;P6=-540;    D=32345634563456345634563456345634565656343434343434;CP=3;SP=2;R=35;m2;␃
+						SDC_PRINT('P'); SDC_PRINT(idx + 48); SDC_PRINT('='); SDC_PRINT(myitoa(pattern[idx], buf)); SDC_PRINT(';');
 					}
 
 					SDC_PRINT("D=");
 
 					for (uint8_t i = mstart; i <= mend; i++)
 					{
-						/* MR to search other Variant
-						SDC_PRINT(message[i]);
-						*/
-						sprintf(buf, "%d", message[i]);
-						SDC_PRINT(buf);
+						//␂MS;P2=-14273;P3=371;P4=-1430;P5=1285;P6=-540;D=    32345634563456345634563456345634565656343434343434    ;CP=3;SP=2;R=35;m2;␃
+						SDC_PRINT(message[i] + 48);
 					}
-					/* MR to search other Variant
-					SDC_PRINT(";CP=");
-					SDC_PRINT(clock);
-					SDC_PRINT(";SP=");
-					SDC_PRINT(sync);
-					SDC_PRINT(';');
-					*/
 
-					/*
-					SDC_PRINT(SERIAL_DELIMITER);
-					SDC_PRINT("CP="); SDC_PRINT(itoa(clock, buf, 10));     SDC_PRINT(SERIAL_DELIMITER);     // ClockPulse
-					SDC_PRINT("SP="); SDC_PRINT(itoa(sync, buf, 10));      SDC_PRINT(SERIAL_DELIMITER);     // SyncPulse
-					SDC_PRINT("R=");  SDC_PRINT(itoa(rssiValue, buf, 10)); SDC_PRINT(SERIAL_DELIMITER);     // Signal Level (RSSI)					
-					*/
-					n = sprintf(buf, ";CP=%i;SP=%i;", clock, sync);
-					SDC_PRINT(buf);
-
+					//␂MS;P2=-14273;P3=371;P4=-1430;P5=1285;P6=-540;D=32345634563456345634563456345634565656343434343434    ;CP=3;SP=2;    R=35;m2;␃
+					SDC_PRINT(";CP="); SDC_PRINT(clock + 48); SDC_PRINT(";SP="); SDC_PRINT(sync + 48); SDC_PRINT(';');
+          
 					if (_rssiCallback != nullptr)
 					{
-						/* MR to search other Variant
-						SDC_PRINT("R=");
-						SDC_PRINT(rssiValue);
-						SDC_PRINT(';');
-						*/
-						n = sprintf(buf, "R=%i;", rssiValue);
-						SDC_PRINT(buf);
+						//␂MS;P2=-14273;P3=371;P4=-1430;P5=1285;P6=-540;D=32345634563456345634563456345634565656343434343434;CP=3;SP=2;    R=35;    m2;␃
+						SDC_PRINT("R="); SDC_PRINT(myitoa(rssiValue, buf)); SDC_PRINT(';');
 					}
 				}
 
 				if (m_overflow) {
+					//␂MS;P1=489;P4=-2045;P5=-3971;P6=-8054;D=1616141414151515141514151414141414141414141515151415151414141414141414141414141415141415;CP=1;SP=6;R=239;    O;    m2;␃
 					SDC_PRINT("O;");
 				}
 				m_truncated = false;
@@ -560,14 +551,9 @@ void SignalDetectorClass::processMessage()
 					bufferMove(mend+1);
 					//SDC_PRINT(F("MS move. messageLen ")); SDC_PRINTLN(messageLen);
 					mstart = 0;
-					/* MR to search other Variant
-					SDC_PRINT('m');
-					SDC_PRINT(MsMoveCount);
-					SDC_PRINT(';');
-					*/
-					//SDC_PRINT("m"); SDC_PRINT(MsMoveCount); SDC_PRINT(SERIAL_DELIMITER);
-					n = sprintf(buf, "m%i;", MsMoveCount);
-					SDC_PRINT(buf);
+
+					//␂MS;P1=489;P4=-2045;P5=-3971;P6=-8054;D=1616141414151515141514151414141414141414141515151415151414141414141414141414141415141415;CP=1;SP=6;R=239;O;    m2;␃
+					SDC_PRINT('m'); SDC_PRINT(MsMoveCount + 48); SDC_PRINT(';');
 				}
 				SDC_PRINT(MSG_END);
 				SDC_PRINT(char(0xA));
@@ -661,7 +647,7 @@ MUOutput:
 
 						for (uint8_t i = 0; i < messageLen; ++i)
 						{
-							SDC_PRINT(itoa(message[i], buf, 10));
+							SDC_PRINT(myitoa(message[i], buf));
 						}
 						SDC_PRINT(';');
 
@@ -671,8 +657,6 @@ MUOutput:
 
 						if (mcDetected) {
 							SDC_PRINT("MD;");
-							/* SDC_PRINT("MD"); */
-							/* SDC_WRITE(SERIAL_DELIMITER); */
 						}
 
 						SDC_PRINTLN(MSG_END);
@@ -681,49 +665,26 @@ MUOutput:
 					if (mcdecoder->doDecode())
 					{
 						SDC_PRINT(MSG_START);
-						/* MR to search other Variant
-						SDC_PRINT("MC;LL="); SDC_PRINT(pattern[mcdecoder->longlow]);
-						SDC_PRINT(";LH="); SDC_PRINT(pattern[mcdecoder->longhigh]);
-						SDC_PRINT(";SL="); SDC_PRINT(pattern[mcdecoder->shortlow]);
-						SDC_PRINT(";SH="); SDC_PRINT(pattern[mcdecoder->shorthigh]);
 
+						//␂    MC;LL=-2926;LH=2935;SL=-1472;SH=1525    ;D=AFF1FFA1;C=1476;L=32;R=0;␃
+						SDC_PRINT("MC;LL="); SDC_PRINT(myitoa(pattern[mcdecoder->longlow], buf));
+						SDC_PRINT(";LH="); SDC_PRINT(myitoa(pattern[mcdecoder->longhigh], buf));
+						SDC_PRINT(";SL="); SDC_PRINT(myitoa(pattern[mcdecoder->shortlow], buf));
+						SDC_PRINT(";SH="); SDC_PRINT(myitoa(pattern[mcdecoder->shorthigh], buf));
+
+						//␂MC;LL=-2926;LH=2935;SL=-1472;SH=1525    ;D=AFF1FFA1;C=1476;L=32;    R=0;␃
 						SDC_PRINT(";D="); mcdecoder->printMessageHexStr();
-						SDC_PRINT(";C="); SDC_PRINT(mcdecoder->clock);
-						SDC_PRINT(";L="); SDC_PRINT(mcdecoder->ManchesterBits.valcount);
+						SDC_PRINT(";C="); SDC_PRINT(myitoa(mcdecoder->clock, buf));
+						SDC_PRINT(";L="); SDC_PRINT(myitoa(mcdecoder->ManchesterBits.valcount, buf));
 						SDC_PRINT(';');
-						*/
-						SDC_PRINT("MC");
-						n = sprintf(buf, ";LL=%i;LH=%i", pattern[mcdecoder->longlow], pattern[mcdecoder->longhigh]);
-						SDC_PRINT(buf);
-						n = sprintf(buf, ";SL=%i;SH=%i;", pattern[mcdecoder->shortlow], pattern[mcdecoder->shorthigh]);
-						SDC_PRINT(buf);
-
-						/*
-						SDC_PRINT("LL="); SDC_PRINT(pattern[mcdecoder->longlow]); SDC_PRINT(SERIAL_DELIMITER);
-						SDC_PRINT("LH="); SDC_PRINT(pattern[mcdecoder->longhigh]); SDC_PRINT(SERIAL_DELIMITER);
-						SDC_PRINT("SL="); SDC_PRINT(pattern[mcdecoder->shortlow]); SDC_PRINT(SERIAL_DELIMITER);
-						SDC_PRINT("SH="); SDC_PRINT(pattern[mcdecoder->shorthigh]); SDC_PRINT(SERIAL_DELIMITER);
-						*/
-						SDC_PRINT("D=");  mcdecoder->printMessageHexStr();
-
-						n = sprintf(buf, ";C=%i;L=%i;", mcdecoder->clock, mcdecoder->ManchesterBits.valcount);
-						SDC_PRINT(buf);
 
 						if (_rssiCallback != nullptr)
 						{
-					    /* MR to search other Variant
-							SDC_PRINT("R=");
-							SDC_PRINT(rssiValue);
-							SDC_PRINT(';');
-							*/
-							n = sprintf(buf, "R=%i;", rssiValue);
-							SDC_PRINT(buf);
-						}						/*
-						SDC_PRINT(SERIAL_DELIMITER);
-						SDC_PRINT("C="); SDC_PRINT(mcdecoder->clock); SDC_PRINT(SERIAL_DELIMITER);
-						SDC_PRINT("L="); SDC_PRINT(mcdecoder->ManchesterBits.valcount); SDC_PRINT(SERIAL_DELIMITER);
-						SDC_PRINT("R=");  SDC_PRINT(rssiValue); SDC_PRINT(SERIAL_DELIMITER);     // Signal Level (RSSI)
-						*/
+							//␂MC;LL=-2926;LH=2935;SL=-1472;SH=1525;D=AFF1FFA1;C=1476;L=32;    R=0;    ␃
+							SDC_PRINT("R="); SDC_PRINT(myitoa(rssiValue, buf)); SDC_PRINT(';');
+						}
+
+						//␂MC;LL=-2926;LH=2935;SL=-1472;SH=1525;D=AFF1FFA1;C=1476;L=32;R=0;    ␃
 						SDC_PRINT(MSG_END);
 						SDC_PRINT(char(0xA));
 
@@ -802,22 +763,14 @@ MUOutput:
 						message.getByte(i, &n);
 						SDC_PRINT(n);
 					}
-					/* MR to search other Variant
-					SDC_PRINT(";C");
-					SDC_PRINT(clock, HEX);
-					SDC_PRINT(';');
-					*/
-					n = sprintf(buf, ";C%X;", clock);
-					SDC_PRINT(buf);
+
+					//␂Mu;���;�؁;���;���;���;�Å;���;�܅;D␁#$TgTTgggggggggggTgggT    ;C7;    R21;␃
+					SDC_PRINT(";C"); SDC_PRINT(clock + 48); SDC_PRINT(';');
+
 					if (_rssiCallback != nullptr)
 					{
-						/* MR to search other Variant
-						SDC_PRINT('R');
-						SDC_PRINT(rssiValue, HEX);
-						SDC_PRINT(';');
-						*/
-						n = sprintf(buf, "R%X;", rssiValue);
-						SDC_PRINT(buf);
+						//␂Mu;���;�؁;���;���;���;�Å;���;�܅;D␁#$TgTTgggggggggggTgggT;C7;    R21;    ␃
+						SDC_PRINT('R'); SDC_PRINTtoHEX(rssiValue); SDC_PRINT(';');
 					}
 				}
 				else {
@@ -828,52 +781,27 @@ MUOutput:
 					for (uint8_t idx = 0; idx < patternLen; idx++)
 					{
 						if (pattern[idx] == 0 || histo[idx] == 0) continue;
-						//SDC_PRINT('P'); SDC_PRINT(idx); SDC_PRINT('='); SDC_PRINT(itoa(pattern[idx], buf, 10)); SDC_PRINT(SERIAL_DELIMITER);
-						n = sprintf(buf, "P%i=%i;", idx, pattern[idx]);
-						SDC_PRINT(buf);
 
-						/* MR to search other Variant
-						SDC_PRINT('P');
-						SDC_PRINT(idx);
-						SDC_PRINT('=');
-						SDC_PRINT(pattern[idx]);
-						SDC_PRINT(';');
-						*/
+						//␂MU;    P0=-32001;P3=373;P4=-1432;P5=1287;P6=-540;    D=34563456345634563456345634563456565634343434343430;CP=3;R=25;␃
+						SDC_PRINT('P'); SDC_PRINT(idx + 48); SDC_PRINT('='); SDC_PRINT(myitoa(pattern[idx], buf)); SDC_PRINT(';');
 					}
+
 					SDC_PRINT("D=");
 
 					for (uint8_t i = 0; i < messageLen; ++i) 
 					{
-						/* MR to search other Variant
-						SDC_PRINT(message[i]);
-						*/
-						sprintf(buf, "%d", message[i]); 
-						SDC_PRINT(buf);
+						//␂MU;P0=-32001;P3=373;P4=-1432;P5=1287;P6=-540;D=    34563456345634563456345634563456565634343434343430    ;CP=3;R=25;␃
+						SDC_PRINT(message[i] + 48);
 					}
 					//String postamble;
-					/* MR to search other Variant
-					SDC_PRINT(";CP=");
-					SDC_PRINT(clock);
-					SDC_PRINT(';');
-					*/
 
-					/*
-					SDC_PRINT(SERIAL_DELIMITER);
-					SDC_PRINT("CP="); SDC_PRINT(clock);     SDC_PRINT(SERIAL_DELIMITER);    // ClockPulse, (not valid for manchester)
-					SDC_PRINT("R=");  SDC_PRINT(rssiValue); SDC_PRINT(SERIAL_DELIMITER);     // Signal Level (RSSI)
-					*/
-					n = sprintf(buf, ";CP=%i;", clock);
-					SDC_PRINT(buf);
+					//␂MU;P0=-32001;P3=373;P4=-1432;P5=1287;P6=-540;D=34563456345634563456345634563456565634343434343430    ;CP=3;    R=25;␃
+					SDC_PRINT(";CP="); SDC_PRINT(clock + 48); SDC_PRINT(';');
 
 					if (_rssiCallback != nullptr)
 					{
-						/* MR to search other Variant
-						SDC_PRINT("R=");
-						SDC_PRINT(rssiValue);
-						SDC_PRINT(';');
-						*/
-						n = sprintf(buf, "R=%i;", rssiValue);
-						SDC_PRINT(buf);
+						//␂MU;P0=-32001;P3=373;P4=-1432;P5=1287;P6=-540;D=34563456345634563456345634563456565634343434343430;CP=3;    R=25;    ␃
+						SDC_PRINT("R="); SDC_PRINT(myitoa(rssiValue, buf)); SDC_PRINT(';');
 					}
 				}
 
@@ -933,6 +861,14 @@ MUOutput:
 	//SDC_PRINTLN("process finished");
 }
 
+
+/* function to convert to HEX without a leading zero */
+void SignalDetectorClass::SDC_PRINTtoHEX(unsigned int numberToPrint) {  // smaller memory variant for sprintf hex output ( sprintf(buf, "R%X;", value) )
+  if (numberToPrint >= 16)
+    SDC_PRINTtoHEX(numberToPrint / 16);
+  /* line is needed, no line - no output !!! */
+  SDC_PRINT("0123456789ABCDEF"[numberToPrint % 16]);
+}
 
 
 void SignalDetectorClass::reset()
@@ -1391,6 +1327,22 @@ const bool ManchesterpatternDecoder::isShort(const uint8_t pulse_idx)
 }
 
 
+/* convert a 4-bit nibble to a hexadecimal character */
+char ManchesterpatternDecoder::nibble_to_HEX(uint8_t nibble) {
+  nibble &= 0xF;
+  return nibble > 9 ? nibble - 10 + 'A' : nibble + '0';
+}
+
+
+/* convert byte to 2 hexadecimal characters | sprintf(cbuffer +1, "%02X", getMCByte(idx) & 0xF); */
+void ManchesterpatternDecoder::HEX_twoDigits(char* cbuffer, uint8_t val)
+{
+  cbuffer[0] = nibble_to_HEX(val >> 4);
+  cbuffer[1] = nibble_to_HEX(val);
+  cbuffer[2] = '\0';
+}
+
+
 /** @brief (Converts decoded manchester bits in a provided string as hex)
 *
 * ()
@@ -1403,29 +1355,21 @@ void ManchesterpatternDecoder::printMessageHexStr()
 	uint8_t idx;
 	// Bytes are stored from left to right in our buffer. We reverse them for better readability
 	for (idx = 0; idx <= ManchesterBits.bytecount - 1; ++idx) {
-		sprintf(cbuffer, "%02X", getMCByte(idx));
-		//SDC_PRINT(hexStr);
+		HEX_twoDigits(cbuffer, getMCByte(idx));
 		pdec->write(cbuffer);
-		/* MR to search other Variant
-		MSG_PRINTtoHEX(getMCByte(idx));
-		*/
 	}
 
-	sprintf(cbuffer, "%01X", getMCByte(idx) >> 4 & 0xf);
-	/* MR to search other Variant
-	MSG_PRINT( (getMCByte(idx) >> 4 & 0xf) , HEX); // SDC_PRINT no HEX support
-	*/
-	//pdec->write(hexStr);
+		//sprintf(cbuffer, "%01X", getMCByte(idx) >> 4 & 0xf);
+		pdec->write(nibble_to_HEX(getMCByte(idx) >> 4 & 0xf));
+		//pdec->write(hexStr);
 	if (ManchesterBits.valcount % 8 > 4 || ManchesterBits.valcount % 8 == 0)
 	{
-		sprintf(cbuffer +1, "%01X", getMCByte(idx) & 0xF);
-		/* MR to search other Variant
-		MSG_PRINT( (getMCByte(idx) & 0xF) , HEX); // SDC_PRINT no HEX support
-		*/
-		//SDC_PRINT(hexStr);
+		//sprintf(cbuffer +1, "%01X", getMCByte(idx) & 0xF);
+		pdec->write(nibble_to_HEX(getMCByte(idx) & 0xF));
 	}
 	//pdec->msgPort->print(cbuffer);
-	pdec->write(cbuffer);
+
+	//pdec->write(cbuffer);
 }
 
 
@@ -1452,29 +1396,13 @@ void ManchesterpatternDecoder::printMessageHexStr()
 	if (!str)
 		return;
 
-	str->concat("LL="); str->concat(pdec->pattern[longlow]); str->concat(';');
-	str->concat("LH="); str->concat(pdec->pattern[longhigh]); str->concat(';');
-	str->concat("SL="); str->concat(pdec->pattern[shortlow]); str->concat(';');
-	str->concat("SH="); str->concat(pdec->pattern[shorthigh]); str->concat(';');
+	str->concat("LL="); str->concat(pdec->pattern[longlow]);
+	str->concat(";LH="); str->concat(pdec->pattern[longhigh]);
+	str->concat(";SL="); str->concat(pdec->pattern[shortlow]);
+	str->concat(";SH="); str->concat(pdec->pattern[shorthigh]); str->concat(';');
 #endif
 }
 
-/** @brief (one liner)
-*
-* (documentation goes here)
-*/
-
-void ManchesterpatternDecoder::printMessagePulseStr()
-{
-	//char cbuffer[50];
-	//sprintf(cbuffer,"LL=%u;LH=%u;SL=%u;SH=%u;", pdec->pattern[longlow], pdec->pattern[longhigh], pdec->pattern[shortlow], pdec->pattern[shorthigh]);
-	//pdec->msgPort->print(cbuffer);
-
-	//SDC_PRINT("LL="); SDC_PRINT(pdec->pattern[longlow]); SDC_PRINT(SERIAL_DELIMITER);
-	//SDC_PRINT("LH="); SDC_PRINT(pdec->pattern[longhigh]); SDC_PRINT(SERIAL_DELIMITER);
-	//SDC_PRINT("SL="); SDC_PRINT(pdec->pattern[shortlow]); SDC_PRINT(SERIAL_DELIMITER);
-	//SDC_PRINT("SH="); SDC_PRINT(pdec->pattern[shorthigh]); SDC_PRINT(SERIAL_DELIMITER);
-}
 
 /** @brief (one liner)
 *
@@ -2033,13 +1961,7 @@ const bool ManchesterpatternDecoder::isManchester()
 								DBG_PRINT(str);
 								sprintf(str, " MC %s:%d", "SH", shorthigh);
 								DBG_PRINT(str);
-								/*
-								DBG_PRINT(" MC LL:"); DBG_PRINT(longlow,DEC);
-								DBG_PRINT(", MC LH:"); DBG_PRINT(longhigh,DEC);
 
-								DBG_PRINT(", MC SL:"); DBG_PRINT(shortlow,DEC);
-								DBG_PRINT(", MC SH:"); DBG_PRINT(shorthigh,DEC);
-								*/
 								DBG_PRINTLN("");
 							#endif
 

--- a/src/_micro-api/libraries/signalDecoder/src/signalDecoder.h
+++ b/src/_micro-api/libraries/signalDecoder/src/signalDecoder.h
@@ -152,7 +152,6 @@ public:
 																		};
 
 	void reset();
-  void SDC_PRINTtoHEX(unsigned int numberToPrint);
 	bool decode(const int* pulse);
 	const status getState();
 	typedef fastdelegate::FastDelegate0<uint8_t> FuncRetuint8t;
@@ -162,6 +161,7 @@ public:
 	void setStreamCallback(Func2pRetuint8t callbackfunction) { _streamCallback = callbackfunction; }
 
 	//private:
+  void SDC_PRINT_intToHex(unsigned int numberToPrint);
 
 	int8_t clock;                           // index to clock in pattern
 	bool MUenabled;

--- a/src/_micro-api/libraries/signalDecoder/src/signalDecoder.h
+++ b/src/_micro-api/libraries/signalDecoder/src/signalDecoder.h
@@ -134,6 +134,8 @@ constexpr const uint8_t MSG_END = 3;
 
 enum status { searching, clockfound, syncfound, detecting, mcdecoding };
 
+char* myitoa(int num, char* str);   // selfmade myitoa function
+
 class ManchesterpatternDecoder;
 class SignalDetectorClass;
 
@@ -150,6 +152,7 @@ public:
 																		};
 
 	void reset();
+  void SDC_PRINTtoHEX(unsigned int numberToPrint);
 	bool decode(const int* pulse);
 	const status getState();
 	typedef fastdelegate::FastDelegate0<uint8_t> FuncRetuint8t;
@@ -245,7 +248,8 @@ public:
 	void getMessageLenStr(String* str);
 #endif
 	void printMessageHexStr();
-	void printMessagePulseStr();
+	char nibble_to_HEX(uint8_t nibble);
+	void HEX_twoDigits(char* cbuffer, uint8_t val);
 
 	const bool isManchester();
 	void reset();

--- a/src/compile_config.h
+++ b/src/compile_config.h
@@ -17,11 +17,9 @@
 /*
  * compiling notes
  * ***************
-  Arduino IDE
-  radino_CC1101@debug  - option too big    - 31288 Bytes (109%), max 28672
 
   Platform IO
-  radino_CC1101@debug  - size (30958 bytes) is greater than maximum allowed (28672 bytes)
+  radino_CC1101@debug  - size (29942 bytes) is greater than maximum allowed (28672 bytes)
 */
 
 
@@ -46,7 +44,7 @@
  * ****************************************
 */
 
-#define PROGVERS               "3.5.0-dev+20201105"
+#define PROGVERS               "3.5.0-dev+20201201"
 
 #ifdef OTHER_BOARD_WITH_CC1101
   #define CMP_CC1101

--- a/src/compile_config.h
+++ b/src/compile_config.h
@@ -44,7 +44,7 @@
  * ****************************************
 */
 
-#define PROGVERS               "3.5.0-dev+20201201"
+#define PROGVERS               "3.5.0-dev+20201204"
 
 #ifdef OTHER_BOARD_WITH_CC1101
   #define CMP_CC1101

--- a/src/signalesp.h
+++ b/src/signalesp.h
@@ -512,7 +512,7 @@ void loop() {
 #define _USE_WRITE_BUFFER
 
 #ifdef _USE_WRITE_BUFFER
-  const size_t writeBufferSize = 128;
+  const size_t writeBufferSize = 256; // old 128
   size_t writeBufferCurrent = 0;
   uint8_t writeBuffer[writeBufferSize];
 #endif


### PR DESCRIPTION
Zusammmenfassung von https://github.com/RFD-FHEM/SIGNALDuino/pull/146

* platformio.ini
  - revised sketch size comments
* signalesp.h
  -  increase writeBufferSize
* compile_config.h
  - revised PROGVERS
  - revised comments
* signalDecoder.h
  - added new functions
* signalDecoder.cpp
  - added new functions myitoa (selfmade alternative to non standard itoa function c++)
  - remove some sprintf and revised to alternate better sketch size function SDC_PRINT
  -  remove old comments
  - added function SDC_PRINTtoHEX / nibble_to_HEX