### PR TITLE
fix writeBufferSize for ESP

### DIFF
--- a/src/compile_config.h
+++ b/src/compile_config.h
@@ -44,7 +44,7 @@
  * ****************************************
 */
 
-#define PROGVERS               "3.5.0-dev+20201204"
+#define PROGVERS               "3.5.0-dev+20201207"
 
 #ifdef OTHER_BOARD_WITH_CC1101
   #define CMP_CC1101

--- a/src/signalesp.h
+++ b/src/signalesp.h
@@ -512,7 +512,7 @@ void loop() {
 #define _USE_WRITE_BUFFER
 
 #ifdef _USE_WRITE_BUFFER
-  const size_t writeBufferSize = 256; // old 128
+  const size_t writeBufferSize = 512;
   size_t writeBufferCurrent = 0;
   uint8_t writeBuffer[writeBufferSize];
 #endif


### PR DESCRIPTION
- entdeckter Bug von @elektron-bbs

Bitte:
1) @sidey79 wenn dieser PR vollzogen ist, wäre ein neues Stand von Release 3.5.0 als Tag sinvoll.

ReRelease notes:
- support receive xFSK with hardware
- optimization of sketch size

2) Einbindung für FHEM -> availableFirmware mit Releasebezeichnung `3.5.0-dev+20201207`