### PR TITLE
Upload compiled firmwares always as artifacs

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -151,3 +151,9 @@ jobs:
           asset_path: ./SIGNALDuino.ino.${{ steps.compile_sketch.outputs.fileext }}
           asset_name: SIGNALDuino_${{ matrix.BOARD }}${{ matrix.RECEIVER }}_${{ github.event.release.tag_name }}.hex
           asset_content_type: application/octet-stream
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: SIGNALDuino_${{ matrix.BOARD }}${{ matrix.RECEIVER }}.hex
+          path: ./SIGNALDuino.ino.${{ steps.compile_sketch.outputs.fileext }}
+          if-no-files-found: warn


### PR DESCRIPTION
Added step to upload compliled firmware as artifacts to always have
a option to get the binarys

## Compiled Firmware is uploaded as artifact after compilation
![image](https://user-images.githubusercontent.com/7968127/102822072-9531d500-43d8-11eb-95ce-a292798798d5.png)

## When all jobs are finished, the artifacts can be retrieved:
![image](https://user-images.githubusercontent.com/7968127/102822622-be069a00-43d9-11eb-82ed-975b4d394e79.png)

![image](https://user-images.githubusercontent.com/7968127/102822680-d1196a00-43d9-11eb-8093-94a8eb6a50da.png)
