### PR TITLE
Fix - GFSK & nano crash

### DIFF
--- a/src/cc1101.cpp
+++ b/src/cc1101.cpp
@@ -5,7 +5,7 @@
 #endif
 
 #define ccMaxBuf 64                  // for cc1101 FIFO, variable is better to revised
-uint8_t cc1101::ccmode = 3;          // MDMCFG2–Modem Configuration Bit 6:4
+uint8_t cc1101::ccmode = 3;          // MDMCFG2–Modem Configuration Bit 6:4 default ASK/OOK
 uint8_t cc1101::revision = 0x01;
 uint8_t ccBuf[ccMaxBuf];             // for cc1101 FIFO, if Circuit board for more cc110x -> ccBuf expand ( ccBuf[radionr][ccMaxBuf] )
 extern volatile bool blinkLED;
@@ -247,7 +247,7 @@ void cc1101::writeCCreg(uint8_t reg, uint8_t var) { // write CC1101 register
 		writeReg(reg - EE_CC1101_CFG, var);
 
 	if (reg - EE_CC1101_CFG == 18) {
-		ccmode = ( var & 0x70 ) >> 4;                // for STM32 - read modulation direct from 0x12 MDMCFG2
+		ccmode = ( var & 0x70 ) >> 4;                // read modulation direct from 0x12 MDMCFG2
 	}
 
     /*
@@ -596,9 +596,9 @@ void cc1101::getRxFifo(uint16_t Boffs) {           // xFSK
 					fifoBytes = ccMaxBuf;
 				}
 				dup = readRXFIFO(fifoBytes);
-				if (cc1101::ccmode != 2 || dup == false) {
+				if (cc1101::ccmode != 2 || dup == false) { // Ralf9: 2 - FIFO ohne dup
 
-					if (cc1101::ccmode != 9) {
+					if (cc1101::ccmode != 9) { // Ralf9: 9 - FIFO mit Debug Ausgaben
 						MSG_PRINT(char(MSG_START));      // SDC_WRITE not work in this scope
 						MSG_PRINT(F("MN;D="));
 					}
@@ -656,7 +656,8 @@ void cc1101::getRxFifo(uint16_t Boffs) {           // xFSK
  * 
  */
 
-			if (marcstate == 17 || cc1101::ccmode == 0) {   // RXoverflow oder LaCrosse?
+      if (marcstate == 17 || cc1101::ccmode != 3) {   // RXoverflow oder nicht ASK/OOK
+//			if (marcstate == 17 || cc1101::ccmode == 0) {   // RXoverflow oder LaCrosse?
 				if (cc1101::flushrx()) {                    // Flush the RX FIFO buffer
 					cc1101::setReceiveMode();
 				}

--- a/src/compile_config.h
+++ b/src/compile_config.h
@@ -45,7 +45,7 @@
 */
 
 
-#define PROGVERS               "3.5.0-dev+20210610"
+#define PROGVERS               "3.5.0-dev+20210611"
 
 #ifdef OTHER_BOARD_WITH_CC1101
   #define CMP_CC1101

--- a/src/compile_config.h
+++ b/src/compile_config.h
@@ -45,7 +45,7 @@
 */
 
 
-#define PROGVERS               "3.5.0-dev+20210615"
+#define PROGVERS               "3.5.0-dev+20210621"
 
 #ifdef OTHER_BOARD_WITH_CC1101
   #define CMP_CC1101

--- a/src/compile_config.h
+++ b/src/compile_config.h
@@ -45,7 +45,7 @@
 */
 
 
-#define PROGVERS               "3.5.0-dev+20210622"
+#define PROGVERS               "3.5.0-dev+20210623"
 
 #ifdef OTHER_BOARD_WITH_CC1101
   #define CMP_CC1101

--- a/src/compile_config.h
+++ b/src/compile_config.h
@@ -45,7 +45,7 @@
 */
 
 
-#define PROGVERS               "3.5.0-dev+20210420"
+#define PROGVERS               "3.5.0-dev+20210610"
 
 #ifdef OTHER_BOARD_WITH_CC1101
   #define CMP_CC1101

--- a/src/compile_config.h
+++ b/src/compile_config.h
@@ -45,7 +45,7 @@
 */
 
 
-#define PROGVERS               "3.5.0-dev+20210611"
+#define PROGVERS               "3.5.0-dev+20210615"
 
 #ifdef OTHER_BOARD_WITH_CC1101
   #define CMP_CC1101

--- a/src/compile_config.h
+++ b/src/compile_config.h
@@ -45,7 +45,7 @@
 */
 
 
-#define PROGVERS               "3.5.0-dev+20210621"
+#define PROGVERS               "3.5.0-dev+20210622"
 
 #ifdef OTHER_BOARD_WITH_CC1101
   #define CMP_CC1101

--- a/src/signalduino.h
+++ b/src/signalduino.h
@@ -97,29 +97,29 @@ void setup() {
   }
 
   // defined states - pullup on for unused pins
-  #ifndef ARDUINO_RADINOCC1101 // not RADINOCC1101
-    #ifdef CMP_CC1101
-      uint8_t offset = 0; // different start of the pins
-      #ifdef ARDUINO_ATMEGA328P_MINICUL
-        offset = 1;
-      #endif
-      
-      for (uint8_t i=4 + offset;i<9 + offset;i++) {
-        pinAsInputPullUp(i);
-      }
-      for (uint8_t i=14 + offset;i<20;i++) {
-        pinAsInputPullUp(i);
-      }
-    #else // Arduino Nano without CC1101
-      for (uint8_t i=3;i<20;i++) { // not PIN_RECEIVE
-        if ( i != PIN_SEND && i != PIN_LED ) {pinAsInputPullUp(i);}
-      }
+  // Start behind RX / TX Pin´s --> all hardware used for system serial 0 & 1
+  // End on Pin 23 --> radino with used highest Pin numbre
+  for (uint8_t i=2;i<24;i++) {
+    // pins for receive, send, LED
+    if (  (i == PIN_RECEIVE) || (i == PIN_SEND) || (i == PIN_LED) ) { continue; }
+
+    // cc1101 pins
+    #if defined(CMP_CC1101)
+      if ((i == csPin) || (i == mosiPin) || (i == misoPin) || (i == sckPin)) { continue; }
     #endif
-  #else // everything except RADINOCC1101
-    for (uint8_t i=2;i<24;i++) {
-      if (i != 4 && ( (i < 7 || i > 9 ) && (i < 13 || i > 17) ) ) {pinAsInputPullUp(i);} // not PIN_Mark,GDO2,SS,GDO0,LED
-    }
-  #endif
+
+    // PIN_MARK433 pin (only on RADINOCC1101 & ATMEGA328P_MINICUL)
+    #if defined(ARDUINO_RADINOCC1101) || defined(ARDUINO_ATMEGA328P_MINICUL)
+      if (i == PIN_MARK433) { continue; }
+    #endif
+
+    // more pins´s (only on RADINOCC1101)
+    #if not defined (ARDUINO_RADINOCC1101)
+      if (i >= 20) { continue; }
+    #endif
+
+    pinAsInputPullUp(i);
+  }
 
   //delay(2000);
   pinAsInput(PIN_RECEIVE);

--- a/src/signalduino.h
+++ b/src/signalduino.h
@@ -102,7 +102,7 @@ void setup() {
   // radino                     --> end on Pin 29 (CCM_radino_CC1101.pdf | sources In-Circuit -> pins_arduino.h)
   for (uint8_t i=2 ; i<=29;i++) {
     #ifndef ARDUINO_RADINOCC1101
-      if (i>=23) break;
+      if (i>23) break;
     #endif
 
     if (i==LED_BUILTIN) continue;

--- a/src/signalduino.h
+++ b/src/signalduino.h
@@ -99,25 +99,22 @@ void setup() {
   // defined states - pullup on for unused pins
   // Start behind RX / TX Pin´s --> all hardware used for system serial 0 & 1
   // End on Pin 23 --> radino with used highest Pin numbre
-  for (uint8_t i=2;i<24;i++) {
-    // pins for receive, send, LED
-    if (  (i == PIN_RECEIVE) || (i == PIN_SEND) || (i == PIN_LED) ) { continue; }
+  for (uint8_t i=2 ; i<=23;i++) {
+    if (i==PIN_LED) continue;
+    if (i==PIN_RECEIVE) continue;
+    if (i==PIN_SEND) continue;
 
-    // cc1101 pins
-    #if defined(CMP_CC1101)
-      if ((i == csPin) || (i == mosiPin) || (i == misoPin) || (i == sckPin)) { continue; }
+    #ifdef CMP_CC1101 
+      if (i==MOSI || i==MISO || i==SCK || i==SS) continue;
     #endif
 
-    // PIN_MARK433 pin (only on RADINOCC1101 & ATMEGA328P_MINICUL)
     #if defined(ARDUINO_RADINOCC1101) || defined(ARDUINO_ATMEGA328P_MINICUL)
-      if (i == PIN_MARK433) { continue; }
-    #endif
+      if (i==PIN_MARK433) continue;
 
-    // more pins´s (only on RADINOCC1101)
-    #if not defined (ARDUINO_RADINOCC1101)
-      if (i >= 20) { continue; }
+      #ifdef ARDUINO_RADINOCC1101
+        if (i==SS || i==17) continue;
+      #endif
     #endif
-
     pinAsInputPullUp(i);
   }
 

--- a/src/signalduino.h
+++ b/src/signalduino.h
@@ -96,7 +96,7 @@ void setup() {
     ; // wait for serial port to connect. Needed for native USB
   }
 
-  for (uint8_t i=2;i<13;i++) {
+  for (uint8_t i=2;i<10;i++) { // all SPI pins excluded! if SPI pins are set to "pinS Input_PullUp" -> crash after a short time!
     pinAsInputPullUp(i);
   }
   //delay(2000);

--- a/src/signalduino.h
+++ b/src/signalduino.h
@@ -96,7 +96,7 @@ void setup() {
     ; // wait for serial port to connect. Needed for native USB
   }
 
-  for (uint8_t i=2;i<10;i++) { // all SPI pins excluded! if SPI pins are set to "pinS Input_PullUp" -> crash after a short time!
+  for (uint8_t i=4;i<10;i++) { // pullup on for unused pins
     pinAsInputPullUp(i);
   }
   //delay(2000);

--- a/src/signalduino.h
+++ b/src/signalduino.h
@@ -96,9 +96,26 @@ void setup() {
     ; // wait for serial port to connect. Needed for native USB
   }
 
-  for (uint8_t i=4;i<10;i++) { // pullup on for unused pins
-    pinAsInputPullUp(i);
-  }
+  // defined states - pullup on for unused pins
+  #ifndef ARDUINO_RADINOCC1101
+    #ifdef CMP_CC1101
+      for (uint8_t i=4;i<9;i++) {
+        pinAsInputPullUp(i);
+      }
+      for (uint8_t i=14;i<20;i++) {
+        pinAsInputPullUp(i);
+      }
+    #else
+      for (uint8_t i=4;i<20;i++) {
+        if (i != 9) pinAsInputPullUp(i); // not LED
+      }
+    #endif
+  #else
+    for (uint8_t i=2;i<24;i++) {
+      if (i != 4 && ( (i < 7 || i > 9 ) && (i < 13 || i > 17) ) ) pinAsInputPullUp(i); // not PIN_Mark,GDO2,SS,GDO0,LED
+    }
+  #endif
+
   //delay(2000);
   pinAsInput(PIN_RECEIVE);
   pinAsOutput(PIN_LED);

--- a/src/signalduino.h
+++ b/src/signalduino.h
@@ -97,9 +97,15 @@ void setup() {
   }
 
   // defined states - pullup on for unused pins
-  // Start behind RX / TX Pin´s --> all hardware used for system serial 0 & 1
-  // End on Pin 23 --> radino with used highest Pin numbre
-  for (uint8_t i=2 ; i<=23;i++) {
+  // start behind RX / TX Pin´s --> all hardware used for system serial 0 & 1
+  // not radino (other boards)  --> end on Pin 23
+  // radino                     --> end on Pin 29 (CCM_radino_CC1101.pdf | sources In-Circuit -> pins_arduino.h)
+  for (uint8_t i=2 ; i<=29;i++) {
+    #ifndef ARDUINO_RADINOCC1101
+      if (i>=23) break;
+    #endif
+
+    if (i==LED_BUILTIN) continue;
     if (i==PIN_LED) continue;
     if (i==PIN_RECEIVE) continue;
     if (i==PIN_SEND) continue;
@@ -112,7 +118,7 @@ void setup() {
       if (i==PIN_MARK433) continue;
 
       #ifdef ARDUINO_RADINOCC1101
-        if (i==SS || i==17) continue;
+        if (i==8 || i==LED_BUILTIN_RX || i==LED_BUILTIN_TX) continue;  // special pin ´s --> ...\packages\In-Circuit\hardware\avr\1.0.0\variants\ictmicro --> pins_arduino.h
       #endif
     #endif
     pinAsInputPullUp(i);

--- a/src/signalduino.h
+++ b/src/signalduino.h
@@ -97,22 +97,27 @@ void setup() {
   }
 
   // defined states - pullup on for unused pins
-  #ifndef ARDUINO_RADINOCC1101
+  #ifndef ARDUINO_RADINOCC1101 // not RADINOCC1101
     #ifdef CMP_CC1101
-      for (uint8_t i=4;i<9;i++) {
+      uint8_t offset = 0; // different start of the pins
+      #ifdef ARDUINO_ATMEGA328P_MINICUL
+        offset = 1;
+      #endif
+      
+      for (uint8_t i=4 + offset;i<9 + offset;i++) {
         pinAsInputPullUp(i);
       }
-      for (uint8_t i=14;i<20;i++) {
+      for (uint8_t i=14 + offset;i<20;i++) {
         pinAsInputPullUp(i);
       }
-    #else
-      for (uint8_t i=4;i<20;i++) {
-        if (i != 9) pinAsInputPullUp(i); // not LED
+    #else // Arduino Nano without CC1101
+      for (uint8_t i=3;i<20;i++) { // not PIN_RECEIVE
+        if ( i != PIN_SEND && i != PIN_LED ) {pinAsInputPullUp(i);}
       }
     #endif
-  #else
+  #else // everything except RADINOCC1101
     for (uint8_t i=2;i<24;i++) {
-      if (i != 4 && ( (i < 7 || i > 9 ) && (i < 13 || i > 17) ) ) pinAsInputPullUp(i); // not PIN_Mark,GDO2,SS,GDO0,LED
+      if (i != 4 && ( (i < 7 || i > 9 ) && (i < 13 || i > 17) ) ) {pinAsInputPullUp(i);} // not PIN_Mark,GDO2,SS,GDO0,LED
     }
   #endif
 


### PR DESCRIPTION
1) Ich bin nun mal so frei und erstelle diesen PR weil beim senden mit dem Nano es zu einem crash kommt. https://github.com/RFD-FHEM/SIGNALDuino/issues/209#issuecomment-858783374
(Das Problem mit dem ESP32 ist ein Anderes)
2) Bugfix GFSK wurde noch behoben. (https://github.com/RFD-FHEM/SIGNALDuino/issues/206)

* Allows other modulations than ASK / OOK and 2-FSK to be received.
* revised PROGVERS
* defined unused pin´s