### PR TITLE
Update signalDecoder.cpp

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -79,9 +79,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
-
-    - name: Checkout submodules
-      uses: textbook/git-checkout-submodule-action@master
+      with: 
+        submodules: true
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1

--- a/src/_micro-api/libraries/signalDecoder/src/signalDecoder.cpp
+++ b/src/_micro-api/libraries/signalDecoder/src/signalDecoder.cpp
@@ -1634,7 +1634,7 @@ const bool ManchesterpatternDecoder::doDecode() {
 					i++;
 				} 
 				#ifdef DEBUGDECODE
-				else if (bit == 0 && mpi == shortlow && mpiPlusOne == shorthigh)	{
+				if (bit == 0 && mpi == shortlow && mpiPlusOne == shorthigh)	{
 					value = 's';
 				} else if (bit == 1 && mpi == shorthigh && mpiPlusOne == shortlow)	{
 					value = 'S';


### PR DESCRIPTION
 * fix, code cannot compile with debug option DEBUGDECODE

- before, an ERROR...

PlatformIO
`src\_micro-api\libraries\signalDecoder\src\signalDecoder.cpp:1637:5: error: expected '}' before 'else'`

ArduinoIDE
```
exit status 1
expected '}' before 'else'
```

- now, no ERROR and FW can compile with option DEBUGDECODE