### PR TITLE
run compile jobs with platformio environment settings

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -80,7 +80,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install PlatformIO Core
-        run: pip install --upgrade platformio
+        run: pip install --upgrade platformio==6.1.6
 
       - name: Run PlatformIO and compile sketch
         id: compile_sketch

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -46,19 +46,20 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - envName: nano328
+          - envName: nano328s
           - envName: nanoCC1101
           - envName: radinoCC1101
-          - envName: pro_promini_16MHz
-          - envName: pro_promini_16MHz_CC1101
-          - envName: pro_promini_8MHz
-          - envName: pro_promini_8MHz_CC1101
-          - envName: esp32
+          - envName: miniculCC1101
+          - envName: promini16s
+          - envName: promini16CC1101
+          - envName: promini8s
+          - envName: promini8CC1101
+          - envName: esp32s
           - envName: esp32CC1101
-          - envName: esp8266
+          - envName: esp8266s
           - envName: esp8266CC1101
           - envName: MAPLEMINI_F103CBcc1101
-          - envName: MAPLEMINI_F103CB
+          - envName: MAPLEMINI_F103CBs
 
     runs-on: ubuntu-latest
     steps:
@@ -108,6 +109,7 @@ jobs:
           path: |
             .pio/build/${{ matrix.envName }}/${{ steps.compile_sketch.outputs.FILENAME }}
           if-no-files-found: warn
+
   release:
     needs: build
     permissions:

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -87,7 +87,9 @@ jobs:
           export COMPILE_OUTPUT=$(pio run -e ${{ matrix.envName }} )
           echo "$COMPILE_OUTPUT"
           FILEEXT=$(find .pio/build/${{ matrix.envName }} -maxdepth 1 \( -name 'SIGNALduino*.bin' -o -name 'SIGNALduino*.hex' \) | while read file; do echo "${file##*.}"; done)
+          FILENAME=$(find .pio/build/${{ matrix.envName }}/ -maxdepth 1 \( -name 'SIGNALduino*.bin' -o -name 'SIGNALduino*.hex' \) -printf "%f" )
           echo "Extension: $FILEEXT"
+          echo "FILENAME=$(echo $FILENAME | tr -d '\n')" >> $GITHUB_OUTPUT
           echo "FILEEXT=$(echo $FILEEXT | tr -d '\n')" >> $GITHUB_OUTPUT
           echo "SKETCHSIZE=$(echo "$COMPILE_OUTPUT" | grep -Po "(^Flash: ).*")" >> $GITHUB_OUTPUT
           echo "GLOBALRAMUSAGE=$(echo "$COMPILE_OUTPUT" | grep -Po "(^RAM: ).*")" >> $GITHUB_OUTPUT
@@ -102,9 +104,9 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
-          name: SIGNALduino_${{ matrix.envName }}.${{ steps.compile_sketch.outputs.FILEEXT }}
+          name: ${{ steps.compile_sketch.outputs.FILENAME }}
           path: |
-            .pio/build/${{ matrix.envName }}/SIGNALduino*.${{ steps.compile_sketch.outputs.FILEEXT }}
+            .pio/build/${{ matrix.envName }}/${{ steps.compile_sketch.outputs.FILENAME }}
           if-no-files-found: warn
   release:
     needs: build

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -4,6 +4,7 @@ on:
     types: [created, prereleased, published]
   workflow_dispatch: null
   pull_request: null
+    
 jobs:
   unittest:
     runs-on: ubuntu-latest
@@ -35,68 +36,30 @@ jobs:
 
   deploy:
     needs: unittest
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:
         include:
-          - BOARD: nano
-            RECEIVER: cc1101
-            arduino-platform: 'arduino:avr'
-            fqbn: 'arduino:avr:nano:cpu=atmega328'
-            compilerflag: '\"-DOTHER_BOARD_WITH_CC1101=1\"'
-          - BOARD: nano328
-            RECEIVER: ""
-            arduino-platform: 'arduino:avr'
-            fqbn: 'arduino:avr:nano:cpu=atmega328'
-          - BOARD: radino
-            RECEIVER: cc1101
-            arduino-platform: 'arduino:avr In-Circuit:avr'
-            fqbn: 'In-Circuit:avr:radinoCC1101'
-            boardurl: '--additional-urls=http://library.radino.cc/Arduino_1_8/package_radino_radino32_index.json'
-            compilerflag: \"-DARDUINO_RADINOCC1101=1\"
-            build_param1: "compiler.path={runtime.tools.avr-gcc-7.3.0-atmel3.6.1-arduino7.path}/bin/"
-          - BOARD: minicul
-            RECEIVER: cc1101
-            arduino-platform: 'arduino:avr'
-            fqbn: 'arduino:avr:pro:cpu=8MHzatmega328'
-            compilerflag: \"-DARDUINO_ATMEGA328P_MINICUL=1\"
-          - BOARD: promini
-            RECEIVER: ""
-            arduino-platform: 'arduino:avr'
-            fqbn: 'arduino:avr:pro:cpu=8MHzatmega328'
-          - BOARD: ESP32
-            RECEIVER: cc1101
-            arduino-platform: 'esp32:esp32@2.0.7'
-            fqbn: 'esp32:esp32:esp32:FlashMode=qio,FlashFreq=80'
-            compilerflag: \"-DOTHER_BOARD_WITH_CC1101=1\"
-            boardurl: '--additional-urls=https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json'
-          - BOARD: ESP32
-            RECEIVER: ""
-            arduino-platform: 'esp32:esp32@2.0.7'
-            fqbn: 'esp32:esp32:esp32:FlashMode=qio,FlashFreq=80'
-            boardurl: '--additional-urls=https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json'
-          - BOARD: ESP8266
-            RECEIVER: cc1101
-            arduino-platform: 'esp8266:esp8266@3.1.2'
-            fqbn: 'esp8266:esp8266:generic:xtal=80,eesz=1M64,FlashMode=qio,FlashFreq=40'
-            compilerflag: \"-DOTHER_BOARD_WITH_CC1101=1\"
-            boardurl: '--additional-urls=http://arduino.esp8266.com/stable/package_esp8266com_index.json'
-          - BOARD: ESP8266
-            RECEIVER: ""
-            arduino-platform: 'esp8266:esp8266@3.1.2'
-            fqbn: 'esp8266:esp8266:generic:xtal=80,eesz=1M64,FlashMode=qio,FlashFreq=40'
-            boardurl: '--additional-urls=http://arduino.esp8266.com/stable/package_esp8266com_index.json'
-          - BOARD: MAPLEMINI_F103CB
-            RECEIVER: cc1101
-            arduino-platform: 'STM32:stm32'
-            fqbn: 'STM32:stm32:GenF1:pnum=MAPLEMINI_F103CB'
-            compilerflag: \"-DOTHER_BOARD_WITH_CC1101=1\"
-            boardurl: '--additional-urls=https://github.com/stm32duino/BoardManagerFiles/raw/master/STM32/package_stm_index.json' 
-          - BOARD: MAPLEMINI_F103CB
-            RECEIVER: ""
-            arduino-platform: 'STM32:stm32'
-            fqbn: 'STM32:stm32:GenF1:pnum=MAPLEMINI_F103CB'
-            boardurl: '--additional-urls=https://github.com/stm32duino/BoardManagerFiles/raw/master/STM32/package_stm_index.json' 
+          - envName: nano_bootl_new
+          - envName: nano_bootl_new_CC1101
+          - envName: nano_bootl_old
+          - envName: nano_bootl_old_CC1101
+          - envName: radino_CC1101
+          - envName: wemos_d1_mini_pro_CC1101
+          - envName: wemos_d1_mini_pro
+          - envName: pro_promini_16MHz
+          - envName: pro_promini_16MHz_CC1101
+          - envName: pro_promini_8MHz
+          - envName: pro_promini_8MHz_CC1101
+          - envName: esp32
+          - envName: esp32_CC1101
+          - envName: esp8266
+          - envName: esp8266_CC1101
+          - envName: maple_mini_bootl_v1_CC1101
+          - envName: maple_mini_bootl_v1
+
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -104,29 +67,33 @@ jobs:
         with: 
           submodules: true
 
-      - name: Install Arduino CLI
-        uses: arduino/setup-arduino-cli@v1.1.1
-
-      - name: Setup arduino-cli
-        uses: ./.github/actions/arduino-cli
+      - uses: actions/cache@v3
         with:
-          boardurl: ${{ matrix.boardurl }}
-          plattform: ${{ matrix.arduino-platform }}
-
-      - name: Compile sketch
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+          key: ${{ matrix.envName }}-pio
+      
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install PlatformIO Core
+        run: pip install --upgrade platformio
+        
+      - name: Run PlatformIO and compile sketch
         id: compile_sketch
         run: |
-          export COMPILE_OUTPUT=$(arduino-cli compile --fqbn ${{ matrix.fqbn }} --build-property="compiler.cpp.extra_flags=${{ matrix.compilerflag }}" ${{ matrix.boardurl }} --build-property="${{ matrix.build_param1 }}" --output-dir=$GITHUB_WORKSPACE $GITHUB_WORKSPACE/src/arduino-ide/SIGNALDuino/SIGNALDuino.ino)
+          export COMPILE_OUTPUT=$(pio run -e ${{ matrix.envName }} )
           echo "$COMPILE_OUTPUT"
-          echo "fileext=$(test -f $GITHUB_WORKSPACE/SIGNALDuino.ino.bin && echo "bin" || echo "hex")" >> $GITHUB_OUTPUT
-          echo "skechsize=$(echo "$COMPILE_OUTPUT" | grep -Po "(?<=^Sketch uses )\d+")" >> $GITHUB_OUTPUT
-          echo "globalramusage=$(echo "$COMPILE_OUTPUT" | grep -Po "(?<=^Global variables use )\d+")" >> $GITHUB_OUTPUT
+          echo "fileext=$(test -f .pio/build/${{ matrix.envName }}/SIGNALDuino*.bin && echo "bin" || echo "hex")" >> $GITHUB_OUTPUT
+          echo "SKETCHSIZE=$(echo "$COMPILE_OUTPUT" | grep -Po "(^Flash: ).*")" >> $GITHUB_OUTPUT
+          echo "GLOBALRAMUSAGE=$(echo "$COMPILE_OUTPUT" | grep -Po "(^RAM: ).*")" >> $GITHUB_OUTPUT
 
       - name: Get flash and ram usage
         id: compile_sizes
         run: |
-          echo Flash usage: ${{ steps.compile_sketch.outputs.skechsize }} bytes
-          echo Ram usage: ${{ steps.compile_sketch.outputs.globalramusage }} bytes   
+          echo  ${{ steps.compile_sketch.outputs.SKETCHSIZE }}
+          echo  ${{ steps.compile_sketch.outputs.GLOBALRAMUSAGE }} 
 
       - name: Find Comment
         if: ${{ github.event.pull_request.number > 0 }}
@@ -144,9 +111,9 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             ### Size report for commit: ${{ github.sha }}
-            | Board | Flash | Ram |
+            | ENV | Flash | Ram |
             |-------|-------|-----|
-            | ${{ matrix.BOARD }}${{ matrix.RECEIVER }} | ${{ steps.compile_sketch.outputs.skechsize }} bytes | ${{ steps.compile_sketch.outputs.globalramusage }} bytes |
+            | ${{ matrix.envName }} | ${{ steps.compile_sketch.outputs.SKETCHSIZE }} bytes | ${{ steps.compile_sketch.outputs.GLOBALRAMUSAGE }} |
 
       - name: Update comment
         if: ${{ github.event.pull_request.number > 0 && steps.fc.outputs.comment-id != 0 && github.event.pull_request.head.repo.fork == false }}
@@ -154,30 +121,25 @@ jobs:
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           body: |
-            | ${{ matrix.BOARD }}${{ matrix.RECEIVER }} | ${{ steps.compile_sketch.outputs.skechsize }} bytes | ${{ steps.compile_sketch.outputs.globalramusage }} bytes |
-
-      - name: Get release
-        id: get_release
-        if: ${{ github.event_name == 'release'}}
-        uses: bruceadams/get-release@v1.3.2
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-
+              | ${{ matrix.envName }} | ${{ steps.compile_sketch.outputs.SKETCHSIZE }} bytes | ${{ steps.compile_sketch.outputs.GLOBALRAMUSAGE }} |
+      
       - name: Upload Release Asset
         id: upload-release-asset 
-        if: ${{ github.event_name == 'release' }}
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
         with:
-          upload_url: ${{ steps.get_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-          asset_path: ./SIGNALDuino.ino.${{ steps.compile_sketch.outputs.fileext }}
-          asset_name: SIGNALDuino_${{ matrix.BOARD }}${{ matrix.RECEIVER }}_${{ github.event.release.tag_name }}.hex
-          asset_content_type: application/octet-stream
+          generate_release_notes: true
+          draft: true
+          files: |
+            .pio/build/${{ matrix.envName }}/SIGNALduino*.bin
+            .pio/build/${{ matrix.envName }}/SIGNALduino*.hex
+  
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
-          name: SIGNALDuino_${{ matrix.BOARD }}${{ matrix.RECEIVER }}.hex
-          path: ./SIGNALDuino.ino.${{ steps.compile_sketch.outputs.fileext }}
+          name: SIGNALDuino_${{ matrix.envName }}
+          path: |
+            .pio/build/${{ matrix.envName }}/SIGNALduino*.bin
+            .pio/build/${{ matrix.envName }}/SIGNALduino*.hex
           if-no-files-found: warn

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -3,8 +3,8 @@ on:
   release:
     types: [created, prereleased, published]
   workflow_dispatch: null
-  pull_request: null
-    
+  push: null
+
 jobs:
   unittest:
     runs-on: ubuntu-latest
@@ -20,6 +20,12 @@ jobs:
       - name: prepare directory
         working-directory: ./tests
         run:  mkdir -p build
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ./tests/build/_deps/
+          key: cmake-deps
       
       - name: cmake prepareBuild
         working-directory: ./tests/build
@@ -34,10 +40,8 @@ jobs:
         run: ctest  -V
 
 
-  deploy:
+  build:
     needs: unittest
-    permissions:
-      contents: write
     strategy:
       fail-fast: false
       matrix:
@@ -66,7 +70,13 @@ jobs:
         uses: actions/checkout@v3
         with: 
           submodules: true
+          fetch-depth: 0
 
+      - name: Extract branch name
+        shell: bash
+        run: echo "gh_branch_name=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_ENV
+        id: extract_branch
+        
       - uses: actions/cache@v3
         with:
           path: |
@@ -85,61 +95,46 @@ jobs:
         run: |
           export COMPILE_OUTPUT=$(pio run -e ${{ matrix.envName }} )
           echo "$COMPILE_OUTPUT"
-          echo "fileext=$(test -f .pio/build/${{ matrix.envName }}/SIGNALDuino*.bin && echo "bin" || echo "hex")" >> $GITHUB_OUTPUT
+          FILEEXT=$(find .pio/build/${{ matrix.envName }} -maxdepth 1 \( -name 'SIGNALduino*.bin' -o -name 'SIGNALduino*.hex' \) | while read file; do echo "${file##*.}"; done)
+          echo "Extension: $FILEEXT"
+          echo "FILEEXT=$(echo $FILEEXT | tr -d '\n')" >> $GITHUB_OUTPUT
           echo "SKETCHSIZE=$(echo "$COMPILE_OUTPUT" | grep -Po "(^Flash: ).*")" >> $GITHUB_OUTPUT
           echo "GLOBALRAMUSAGE=$(echo "$COMPILE_OUTPUT" | grep -Po "(^RAM: ).*")" >> $GITHUB_OUTPUT
 
-      - name: Get flash and ram usage
-        id: compile_sizes
+      - name: Create Job Summary
         run: |
-          echo  ${{ steps.compile_sketch.outputs.SKETCHSIZE }}
-          echo  ${{ steps.compile_sketch.outputs.GLOBALRAMUSAGE }} 
-
-      - name: Find Comment
-        if: ${{ github.event.pull_request.number > 0 }}
-        uses: peter-evans/find-comment@v2
-        id: fc
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body-includes: ${{ github.sha }}
-      
-      - name: Create comment
-        if: ${{ github.event.pull_request.number > 0 && steps.fc.outputs.comment-id == 0  && github.event.pull_request.head.repo.fork == false }}
-
-        uses: peter-evans/create-or-update-comment@v2
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            ### Size report for commit: ${{ github.sha }}
-            | ENV | Flash | Ram |
-            |-------|-------|-----|
-            | ${{ matrix.envName }} | ${{ steps.compile_sketch.outputs.SKETCHSIZE }} bytes | ${{ steps.compile_sketch.outputs.GLOBALRAMUSAGE }} |
-
-      - name: Update comment
-        if: ${{ github.event.pull_request.number > 0 && steps.fc.outputs.comment-id != 0 && github.event.pull_request.head.repo.fork == false }}
-        uses: peter-evans/create-or-update-comment@v2
-        with:
-          comment-id: ${{ steps.fc.outputs.comment-id }}
-          body: |
-              | ${{ matrix.envName }} | ${{ steps.compile_sketch.outputs.SKETCHSIZE }} bytes | ${{ steps.compile_sketch.outputs.GLOBALRAMUSAGE }} |
-      
-      - name: Upload Release Asset
-        id: upload-release-asset 
-        uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          generate_release_notes: true
-          draft: true
-          files: |
-            .pio/build/${{ matrix.envName }}/SIGNALduino*.bin
-            .pio/build/${{ matrix.envName }}/SIGNALduino*.hex
-  
+          echo "### Size report for commit: ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+          echo "| ENV | Flash | Ram |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------|-------|-----|" >> $GITHUB_STEP_SUMMARY
+          echo "| ${{ matrix.envName }} | ${{ steps.compile_sketch.outputs.SKETCHSIZE }} | ${{ steps.compile_sketch.outputs.GLOBALRAMUSAGE }} |" >> $GITHUB_STEP_SUMMARY
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
-          name: SIGNALDuino_${{ matrix.envName }}
+          name: SIGNALduino_${{ matrix.envName }}.${{ steps.compile_sketch.outputs.FILEEXT }}
           path: |
-            .pio/build/${{ matrix.envName }}/SIGNALduino*.bin
-            .pio/build/${{ matrix.envName }}/SIGNALduino*.hex
+            .pio/build/${{ matrix.envName }}/SIGNALduino*.${{ steps.compile_sketch.outputs.FILEEXT }}
           if-no-files-found: warn
+  release:
+    needs: build
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download artifact
+        id: download
+        uses: actions/download-artifact@v3
+
+      - name: 'Echo download path'
+        run: ls -R ${{steps.download.outputs.download-path}}
+
+      - name: Upload Release Asset
+        id: upload-release-asset 
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          generate_release_notes: true
+          draft: true
+          files: |
+            ${{steps.download.outputs.download-path}}/SIGNALduino*/SIGNALduino*

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -3,7 +3,7 @@ on:
   release:
     types: [created, prereleased, published]
   workflow_dispatch: null
-  push: null
+  pull_request:
 
 jobs:
   unittest:
@@ -46,23 +46,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - envName: nano_bootl_new
-          - envName: nano_bootl_new_CC1101
-          - envName: nano_bootl_old
-          - envName: nano_bootl_old_CC1101
-          - envName: radino_CC1101
-          - envName: wemos_d1_mini_pro_CC1101
-          - envName: wemos_d1_mini_pro
+          - envName: nano328
+          - envName: nanoCC1101
+          - envName: radinoCC1101
           - envName: pro_promini_16MHz
           - envName: pro_promini_16MHz_CC1101
           - envName: pro_promini_8MHz
           - envName: pro_promini_8MHz_CC1101
           - envName: esp32
-          - envName: esp32_CC1101
+          - envName: esp32CC1101
           - envName: esp8266
-          - envName: esp8266_CC1101
-          - envName: maple_mini_bootl_v1_CC1101
-          - envName: maple_mini_bootl_v1
+          - envName: esp8266CC1101
+          - envName: MAPLEMINI_F103CBcc1101
+          - envName: MAPLEMINI_F103CB
 
     runs-on: ubuntu-latest
     steps:
@@ -72,24 +68,19 @@ jobs:
           submodules: true
           fetch-depth: 0
 
-      - name: Extract branch name
-        shell: bash
-        run: echo "gh_branch_name=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_ENV
-        id: extract_branch
-        
       - uses: actions/cache@v3
         with:
           path: |
             ~/.cache/pip
             ~/.platformio/.cache
           key: ${{ matrix.envName }}-pio
-      
+
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
       - name: Install PlatformIO Core
         run: pip install --upgrade platformio
-        
+
       - name: Run PlatformIO and compile sketch
         id: compile_sketch
         run: |

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -1,10 +1,10 @@
 name: unittest
 on:
-  release:
-    types: [created, prereleased, published]
   workflow_dispatch: null
-  pull_request:
-
+  pull_request: 
+  push:
+    tags:
+      - '**'
 jobs:
   unittest:
     runs-on: ubuntu-latest

--- a/SIGNALDuino.code-workspace
+++ b/SIGNALDuino.code-workspace
@@ -1,114 +1,37 @@
 {
-    "settings": {
-        "editor.tokenColorCustomizations": {
-            "textMateRules": [
-                {
-                    "scope": "googletest.failed",
-                    "settings": {
-                        "foreground": "#f00"
-                    }
-                },
-                {
-                    "scope": "googletest.passed",
-                    "settings": {
-                        "foreground": "#0f0"
-                    }
-                },
-                {
-                    "scope": "googletest.run",
-                    "settings": {
-                        "foreground": "#0f0"
-                    }
-                }
-            ]
-        },
-        "files.associations": {
-            "xstring": "cpp",
-            "bitset": "cpp",
-            "sstream": "cpp",
-            "limits": "cpp",
-            "istream": "cpp",
-            "*.tcc": "cpp",
-            "iosfwd": "cpp",
-            "xlocale": "cpp",
-            "string_view": "cpp",
-            "array": "cpp",
-            "deque": "cpp",
-            "initializer_list": "cpp",
-            "list": "cpp",
-            "queue": "cpp",
-            "random": "cpp",
-            "type_traits": "cpp",
-            "vector": "cpp",
-            "xhash": "cpp",
-            "xtree": "cpp",
-            "xutility": "cpp",
-            "utility": "cpp",
-            "ostream": "cpp",
-            "algorithm": "cpp",
-            "atomic": "cpp",
-            "cctype": "cpp",
-            "chrono": "cpp",
-            "clocale": "cpp",
-            "cmath": "cpp",
-            "condition_variable": "cpp",
-            "cstdarg": "cpp",
-            "cstddef": "cpp",
-            "cstdint": "cpp",
-            "cstdio": "cpp",
-            "cstdlib": "cpp",
-            "cstring": "cpp",
-            "ctime": "cpp",
-            "cwchar": "cpp",
-            "cwctype": "cpp",
-            "exception": "cpp",
-            "forward_list": "cpp",
-            "fstream": "cpp",
-            "functional": "cpp",
-            "iomanip": "cpp",
-            "ios": "cpp",
-            "iostream": "cpp",
-            "iterator": "cpp",
-            "locale": "cpp",
-            "map": "cpp",
-            "memory": "cpp",
-            "mutex": "cpp",
-            "new": "cpp",
-            "numeric": "cpp",
-            "optional": "cpp",
-            "ratio": "cpp",
-            "set": "cpp",
-            "shared_mutex": "cpp",
-            "stdexcept": "cpp",
-            "streambuf": "cpp",
-            "string": "cpp",
-            "system_error": "cpp",
-            "thread": "cpp",
-            "tuple": "cpp",
-            "typeinfo": "cpp",
-            "unordered_map": "cpp",
-            "unordered_set": "cpp",
-            "xfacet": "cpp",
-            "xiosbase": "cpp",
-            "xlocbuf": "cpp",
-            "xlocinfo": "cpp",
-            "xlocmes": "cpp",
-            "xlocmon": "cpp",
-            "xlocnum": "cpp",
-            "xloctime": "cpp",
-            "xmemory": "cpp",
-            "xmemory0": "cpp",
-            "xstddef": "cpp",
-            "xtr1common": "cpp",
-            "cinttypes": "cpp"
-        }
-    },
-    "folders": [
-        {
-            "path": "."
-        },
-        {
-            "path": "tests"
-        }
-    ]
+	"folders": [
+		{
+			"path": "."
+		},
+		{
+			"path": "tests"
+		}
+	],
+	"settings": {
+		"editor.tokenColorCustomizations": {
+			"textMateRules": [
+				{
+					"scope": "googletest.failed",
+					"settings": {
+						"foreground": "#f00"
+					}
+				},
+				{
+					"scope": "googletest.passed",
+					"settings": {
+						"foreground": "#0f0"
+					}
+				},
+				{
+					"scope": "googletest.run",
+					"settings": {
+						"foreground": "#0f0"
+					}
+				}
+			]
+		},
+		"gtest-adapter.debugConfig": [
+			"PIO Debug"
+		]
+	}
 }

--- a/extra_script.py
+++ b/extra_script.py
@@ -39,7 +39,7 @@ basetag = (
 if (reftype == 'branch') :
     build_version = basetag+os.environ.get('GITHUB_HEAD_REF')+"+"+date
 elif (reftype == 'tag') :
-    build_version = os.environ.get('GITHUB_HEAD_REF',basetag+"+"+date)
+    build_version = os.environ.get('GITHUB_REF_NAME',basetag+"+"+date)
 else:
     build_version = basetag+"+"+date
 

--- a/extra_script.py
+++ b/extra_script.py
@@ -13,65 +13,57 @@ Import("env")
 
 ### to build date str and buildname
 import datetime
-date = datetime.datetime.now()
-date = date.strftime("%y") + date.strftime("%m") + date.strftime("%d")
+import subprocess
+import os
+import platform
+date = datetime.datetime.now().strftime("%y%m%d")
 
 # for config.get
 # config = configparser.ConfigParser()
 # config.read("platformio.ini")
 # build_version = config.get("env", "BUILD_FLAGS")
 
-
 # name from env:project | example: [env:nano_bootl_old_CC1101] 
 build_name = env['PIOENV']
 
 # Build versions with a point are difficult to process
 # System uses dot for file extension
-build_release = "350_"
-build_version = "v" + build_release + date
-
-# write project hex, bin, elf to nano_bootl_old_CC1101_v350_dev_20200811.hex
-env.Replace(PROGNAME="%s" % build_name + "_" + "%s" % build_version)
 
 
+basetag = (
+    subprocess.check_output(["git", "describe", "--tags", "--first-parent", "--abbrev=1"])
+    .strip()
+    .decode("utf-8")
+)
 
-### copy file to subfolder
-## this relief works from the 2nd run
-movehelp = "no"
+build_version = os.environ.get('GITHUB_REF_NAME',basetag+"+"+date)
 
-if movehelp == "yes":
- from pathlib import Path
- import shutil
- import platform
+# write project hex, bin, elf like SIGANALduino_esp32_CC1101_3.5.0-11-gcc56+230423.bin
+env.Replace(PROGNAME="SIGANALduino_{0}_{1}".format(build_name,build_version))
 
- current_path = env['PROJECT_BUILD_DIR']
- 
- ## OS check ##
- if platform.system() == "Windows":
-  current_file = env['PROJECT_BUILD_DIR'] + "\\" +  build_name + "\\" + env['PIOENV'] + "_" + "%s" % build_version
-  new_file_bin = env['PROJECT_BUILD_DIR'] + "\\" + env['PIOENV'] + "_" + "%s" % build_version + ".bin"
-  new_file_hex = env['PROJECT_BUILD_DIR'] + "\\" + env['PIOENV'] + "_" + "%s" % build_version + ".hex"
+env.Append(CPPDEFINES=[
+    ("PROGVERS",env.StringifyMacro(build_version)),
+])
 
- if platform.system() == "Linux":
-  current_file = env['PROJECT_BUILD_DIR'] + "/" +  build_name + "/" + env['PIOENV'] + "_" + "%s" % build_version
-  new_file_bin = env['PROJECT_BUILD_DIR'] + "/" + env['PIOENV'] + "_" + "%s" % build_version + ".bin"
-  new_file_hex = env['PROJECT_BUILD_DIR'] + "/" + env['PIOENV'] + "_" + "%s" % build_version + ".hex"
-  
- current_file_bin = Path(current_file + ".bin")
- current_file_hex = Path(current_file + ".hex")
 
- ## if bin file exists, copy to subfolder
- if current_file_bin.is_file():
-  print("- bin file exists -")
-  print(current_file_bin)
-  print("- bin file to -")
-  print(new_file_bin)
-  shutil.copyfile(str(current_file_bin), str(new_file_bin))
+#Copy functions has to be finished, it does currently not work
+def copy_firmware(source, target, env):
 
- ## if hex file exists, copy to subfolder
- if current_file_hex.is_file():
-  print("- hex file exists -")
-  print(current_file_hex)
-  print("- hex file to -")
-  print(new_file_hex)
-  shutil.copyfile(str(current_file_hex), str(new_file_hex))
+    from pathlib import Path
+    import shutil
+    filename= source
+    if env["PIOPLATFORM"] == "espressif32" or env["PIOPLATFORM"] == "espressif8266":
+        filename = source + ".bin"
+    else:
+        filename = source + ".hex"
+    
+    print (filename)
+    ## if bin file exists, copy to subfolder
+    # shutil.copyfile(str(filename), str(BUILD_DIR))
+
+
+#if platform.system() == "Windows":
+#    env.AddPostAction("$BUILD_DIR\\${PROGNAME}", copy_firmware)
+
+#if platform.system() == "Linux":
+#    env.AddPostAction("$BUILD_DIR/${PROGNAME}", copy_firmware)

--- a/extra_script.py
+++ b/extra_script.py
@@ -37,9 +37,9 @@ basetag = (
 )
 
 if (reftype == 'branch') :
-    build_version = basetag+os.environ.get('GITHUB_REF_NAME')+"+"+date
+    build_version = basetag+os.environ.get('GITHUB_HEAD_REF')+"+"+date
 elif (reftype == 'tag') :
-    build_version = os.environ.get('GITHUB_REF_NAME',basetag+"+"+date)
+    build_version = os.environ.get('GITHUB_HEAD_REF',basetag+"+"+date)
 else:
     build_version = basetag+"+"+date
 

--- a/extra_script.py
+++ b/extra_script.py
@@ -29,17 +29,22 @@ build_name = env['PIOENV']
 # Build versions with a point are difficult to process
 # System uses dot for file extension
 
-
+reftype = os.environ.get('GITHUB_REF_TYPE','local')
 basetag = (
     subprocess.check_output(["git", "describe", "--tags", "--first-parent", "--abbrev=1"])
     .strip()
     .decode("utf-8")
 )
 
-build_version = os.environ.get('GITHUB_REF_NAME',basetag+"+"+date)
+if (reftype == 'branch') :
+    build_version = basetag+os.environ.get('GITHUB_REF_NAME')+"+"+date
+elif (reftype == 'tag') :
+    build_version = os.environ.get('GITHUB_REF_NAME',basetag+"+"+date)
+else:
+    build_version = basetag+"+"+date
 
 # write project hex, bin, elf like SIGANALduino_esp32_CC1101_3.5.0-11-gcc56+230423.bin
-env.Replace(PROGNAME="SIGANALduino_{0}_{1}".format(build_name,build_version))
+env.Replace(PROGNAME="SIGNALduino_{0}_{1}".format(build_name,build_version))
 
 env.Append(CPPDEFINES=[
     ("PROGVERS",env.StringifyMacro(build_version)),

--- a/platformio.ini
+++ b/platformio.ini
@@ -84,7 +84,7 @@ monitor_port = ${env_esp.monitor_port}
 upload_port = ${env.upload_port}
 build_flags=-D OTHER_BOARD_WITH_CC1101=1
 
-[env:esp32@debug]
+[env:esp32s@debug]
 platform = espressif32@6.0.1
 board = nodemcu-32s
 framework = arduino
@@ -94,7 +94,7 @@ monitor_port = ${env_esp.monitor_port}
 upload_port = ${env.upload_port}
 build_flags=-D DEBUG
 
-[env:esp32]
+[env:esp32s]
 platform = espressif32@6.0.1
 board = nodemcu-32s
 framework = arduino
@@ -146,7 +146,7 @@ monitor_speed = 115200
 lib_deps =
 build_flags=-D DEBUG
 
-[env:esp8266]
+[env:esp8266s]
 ; Espressif ESP8266 - single core, max 160 MHz, GPIO 17, power consumption 80 mA
 ; RAM:   [====      ]  39.1% (used 32020 bytes from 81920 bytes)
 ; Flash: [===       ]  34.9% (used 364700 bytes from 1044464 bytes)
@@ -208,7 +208,7 @@ build_flags = ${env_maple_mini.build_flags}
  -D ARDUINO_MAPLEMINI_F103CB=1
  -D OTHER_BOARD_WITH_CC1101=1
 
-[env:MAPLEMINI_F103CB]
+[env:MAPLEMINI_F103CBs]
 ; ST-Microelectronics STM32F103C8T6 bootloader v1.0
 ; RAM:   [===       ]  29.1% (used 5968 bytes from 20480 bytes)
 ; Flash: [====      ]  41.7% (used 46144 bytes from 110592 bytes)
@@ -303,7 +303,7 @@ upload_port = ${env.upload_port}
 build_flags=-D OTHER_BOARD_WITH_CC1101=1
 
 
-[env:nano_bootl_new@debug]
+[env:nano_bootl_news@debug]
 ; Arduino Nano ATmega328 - bootloader Optiboot
 ; RAM:   [=====     ]  51.3% (used 1050 bytes from 2048 bytes)
 ; Flash: [========  ]  77.2% (used 23724 bytes from 30720 bytes)
@@ -317,7 +317,7 @@ build_flags = -D DEBUG
 build_src_filter = -cc1101.h -cc1101.cpp +<*> -<.git/> -<.svn/> -<example/> -<examples/> -<arduino-ide/SIGNALDuino/> -<_micro-api/libraries/ArduinoJson/test/> -<_micro-api/libraries/ArduinoJson/third-party/> -<_micro-api/libraries/fastdelegate/examples/>-<test/> -<tests/> -<_micro-api/libraries/ArduinoJson/fuzzing/>
 
 
-[env:nano_bootl_new]
+[env:nano_bootl_news]
 ; Arduino Nano ATmega328 - bootloader Optiboot
 ; RAM:   [====      ]  42.1% (used 862 bytes from 2048 bytes)
 ; Flash: [=======   ]  69.8% (used 21452 bytes from 30720 bytes)
@@ -328,6 +328,30 @@ framework = arduino
 monitor_port = ${env.monitor_port}
 upload_port = ${env.upload_port}
 build_flags=
+
+[env:miniculCC1101]
+; Minicul with cc1101 running at 8 mhz
+; RAM:   [====      ]  42.1% (used 862 bytes from 2048 bytes)
+; Flash: [=======   ]  69.7% (used 21406 bytes from 30720 bytes)
+platform = atmelavr
+board = pro8MHzatmega328
+framework = arduino
+monitor_speed = 57600
+monitor_port = ${env.monitor_port}
+upload_port = ${env.upload_port}
+build_flag = -D ARDUINO_ATMEGA328P_MINICUL=1
+
+[env:miniculCC1101@debug]
+; Minicul with cc1101 running at 8 mhz
+; RAM:   [====      ]  42.1% (used 862 bytes from 2048 bytes)
+; Flash: [=======   ]  69.7% (used 21406 bytes from 30720 bytes)
+platform = atmelavr
+board = pro8MHzatmega328
+framework = arduino
+monitor_speed = 57600
+monitor_port = ${env.monitor_port}
+upload_port = ${env.upload_port}
+build_flag = -D ARDUINO_ATMEGA328P_MINICUL=1 -D DEBUG
 
 
 [env:io]
@@ -354,7 +378,7 @@ monitor_port = ${env.monitor_port}
 upload_port = ${env.upload_port}
 build_flags=-D OTHER_BOARD_WITH_CC1101=1 -D DEBUG
 
-[env:nano328]
+[env:nano328s]
 platform = atmelavr
 board = nanoatmega328
 build_flags=
@@ -393,7 +417,7 @@ upload_port = ${env.upload_port}
 build_flags = -D DEBUG
 build_src_filter = -cc1101.h -cc1101.cpp +<*> -<.git/> -<.svn/> -<example/> -<examples/> -<arduino-ide/SIGNALDuino/> -<_micro-api/libraries/ArduinoJson/test/> -<_micro-api/libraries/ArduinoJson/third-party/> -<_micro-api/libraries/fastdelegate/examples/>-<test/> -<tests/> -<_micro-api/libraries/ArduinoJson/fuzzing/>
 
-[env:nano_bootl_old]
+[env:nano_bootl_olds]
 ; Arduino Nano ATmega328 - bootloader ATmegaBOOT
 ; RAM:   [====      ]  42.1% (used 862 bytes from 2048 bytes)
 ; Flash: [=======   ]  70.2% (used 21564 bytes from 30720 bytes)
@@ -405,7 +429,7 @@ monitor_port = ${env.monitor_port}
 upload_port = ${env.upload_port}
 build_flags=
 
-[env:pro_promini_16MHz_CC1101@debug]
+[env:promini16CC1101@debug]
 ; Arduino Pro or Pro Mini - Atmel ATmega328 running at 16MHz
 ; RAM:   [=====     ]  54.2% (used 1109 bytes from 2048 bytes)
 ; Flash: [========= ]  90.0% (used 27638 bytes from 30720 bytes)
@@ -417,7 +441,7 @@ monitor_port = ${env.monitor_port}
 upload_port = ${env.upload_port}
 build_flags=-D OTHER_BOARD_WITH_CC1101=1 -D DEBUG
 
-[env:pro_promini_16MHz_CC1101]
+[env:promini16CC1101]
 ; Arduino Pro or Pro Mini - Atmel ATmega328 running at 16MHz
 ; RAM:   [====      ]  45.0% (used 921 bytes from 2048 bytes)
 ; Flash: [========  ]  80.8% (used 24820 bytes from 30720 bytes)
@@ -429,7 +453,7 @@ monitor_port = ${env.monitor_port}
 upload_port = ${env.upload_port}
 build_flags=-D OTHER_BOARD_WITH_CC1101=1 
 
-[env:pro_promini_16MHz@debug]
+[env:promini16s@debug]
 ; Arduino Pro or Pro Mini - Atmel ATmega328 running at 8MHz
 ; RAM:   [=====     ]  51.3% (used 1050 bytes from 2048 bytes)
 ; Flash: [========  ]  77.2% (used 23724 bytes from 30720 bytes)
@@ -441,7 +465,7 @@ monitor_port = ${env.monitor_port}
 upload_port = ${env.upload_port}
 build_flags=-D DEBUG
 
-[env:pro_promini_16MHz]
+[env:promini16s]
 ; Arduino Pro or Pro Mini - Atmel ATmega328 running at 16MHz
 ; RAM:   [====      ]  42.1% (used 862 bytes from 2048 bytes)
 ; Flash: [=======   ]  70.2% (used 21554 bytes from 30720 bytes)
@@ -453,7 +477,7 @@ monitor_port = ${env.monitor_port}
 upload_port = ${env.upload_port}
 build_flags=
 
-[env:pro_promini_8MHz_CC1101@debug]
+[env:promini8CC1101@debug]
 ; Arduino Pro or Pro Mini - Atmel ATmega328 running at 8MHz
 ; RAM:   [=====     ]  53.8% (used 1101 bytes from 2048 bytes)
 ; Flash: [========= ]  90.1% (used 27684 bytes from 30720 bytes)
@@ -465,7 +489,7 @@ monitor_port = ${env.monitor_port}
 upload_port = ${env.upload_port}
 build_flags=-D OTHER_BOARD_WITH_CC1101=1 -D DEBUG
 
-[env:pro_promini_8MHz_CC1101]
+[env:promini8CC1101]
 ; Arduino Pro or Pro Mini - Atmel ATmega328 running at 8MHz
 ; RAM:   [====      ]  44.6% (used 913 bytes from 2048 bytes)
 ; Flash: [========  ]  80.9% (used 24866 bytes from 30720 bytes)
@@ -477,7 +501,7 @@ monitor_port = ${env.monitor_port}
 upload_port = ${env.upload_port}
 build_flags=-D OTHER_BOARD_WITH_CC1101=1
 
-[env:pro_promini_8MHz@debug]
+[env:promini8s@debug]
 ; Arduino Pro or Pro Mini - Atmel ATmega328 running at 8MHz
 ; RAM:   [=====     ]  50.9% (used 1042 bytes from 2048 bytes)
 ; Flash: [========  ]  77.4% (used 23768 bytes from 30720 bytes)
@@ -489,7 +513,7 @@ monitor_port = ${env.monitor_port}
 upload_port = ${env.upload_port}
 build_flags=-D DEBUG
 
-[env:pro_promini_8MHz]
+[env:promini8s]
 ; Arduino Pro or Pro Mini - Atmel ATmega328 running at 8MHz
 ; RAM:   [====      ]  41.7% (used 854 bytes from 2048 bytes)
 ; Flash: [=======   ]  70.3% (used 21610 bytes from 30720 bytes)
@@ -548,7 +572,7 @@ monitor_port = ${env.monitor_port}
 upload_port = ${env.upload_port}
 build_flags = -D PIN_LED_INVERSE=1 -D OTHER_BOARD_WITH_CC1101=1 -D DEBUG
 
-[env:wemos_d1_mini_pro_CC1101]
+[env:wemos_d1_mini_proCC1101]
 ; Espressif ESP8266 WeMos D1 mini pro - single core, max 160MHz, GPIO 11, power consumption 70 mA
 ; RAM:   [====      ]  39.0% (used 31944 bytes from 81920 bytes)
 ; Flash: [====      ]  35.4% (used 370212 bytes from 1044464 bytes)
@@ -560,7 +584,7 @@ monitor_port = ${env.monitor_port}
 upload_port = ${env.upload_port}
 build_flags=-D PIN_LED_INVERSE=1 -D OTHER_BOARD_WITH_CC1101=1
 
-[env:wemos_d1_mini_pro@debug]
+[env:wemos_d1_mini_pros@debug]
 ; Espressif ESP8266 WeMos D1 mini pro - single core, max 160MHz, GPIO 11, power consumption 70 mA
 ; RAM:   [====      ]  39.1% (used 32052 bytes from 81920 bytes)
 ; Flash: [====      ]  35.2% (used 367404 bytes from 1044464 bytes)
@@ -572,7 +596,7 @@ monitor_port = ${env.monitor_port}
 upload_port = ${env.upload_port}
 build_flags=-D PIN_LED_INVERSE=1 -D DEBUG
 
-[env:wemos_d1_mini_pro]
+[env:wemos_d1_mini_pros]
 ; Espressif ESP8266 WeMos D1 mini pro - single core, max 160MHz, GPIO 11, power consumption 70 mA
 ; RAM:   [====      ]  38.9% (used 31876 bytes from 81920 bytes)
 ; Flash: [===       ]  34.9% (used 364828 bytes from 1044464 bytes)

--- a/platformio.ini
+++ b/platformio.ini
@@ -66,7 +66,7 @@ build_flags=
 ; behind this lines, all hardware projects
 ; * * * * * * * * * * * * * * * * * * * * *
 
-[env:esp32_CC1101@debug]
+[env:esp32CC1101@debug]
 platform = espressif32@6.0.1
 board = nodemcu-32s
 framework = arduino
@@ -75,7 +75,7 @@ monitor_speed = 115200
 #upload_port = ${env.upload_port}
 build_flags = -D DEBUG -D OTHER_BOARD_WITH_CC1101=1
 
-[env:esp32_CC1101]
+[env:esp32CC1101]
 platform = espressif32@6.0.1
 board = nodemcu-32s
 framework = arduino
@@ -104,7 +104,7 @@ monitor_port = ${env_esp.monitor_port}
 upload_port = ${env.upload_port}
 build_flags=
 
-[env:esp8266_CC1101@debug]
+[env:esp8266CC1101@debug]
 ; Espressif ESP8266 - single core, max 160 MHz, GPIO 17, power consumption 80 mA
 ; RAM:   [====      ]  39.4% (used 32260 bytes from 81920 bytes)
 ; Flash: [====      ]  35.8% (used 373456 bytes from 1044464 bytes)
@@ -118,7 +118,7 @@ monitor_speed = 115200
 lib_deps =
 build_flags=-D DEBUG -D OTHER_BOARD_WITH_CC1101=1
 
-[env:esp8266_CC1101]
+[env:esp8266CC1101]
 ; Espressif ESP8266 - single core, max 160 MHz, GPIO 17, power consumption 80 mA
 ; RAM:   [====      ]  39.2% (used 32072 bytes from 81920 bytes)
 ; Flash: [====      ]  35.4% (used 370084 bytes from 1044464 bytes)
@@ -160,7 +160,7 @@ monitor_speed = 115200
 lib_deps=
 build_flags=
 
-[env:maple_mini_bootl_v1_CC1101@debug_wr]
+[env:MAPLEMINI_F103CB@debug_wr]
 ; ST-Microelectronics STM32F103C8T6 bootloader v1.0
 ; RAM:   [===       ]  29.5% (used 6032 bytes from 20480 bytes)
 ; Flash: [=====     ]  50.3% (used 55600 bytes from 110592 bytes)
@@ -177,7 +177,7 @@ build_flags = ${env_maple_mini.build_flags}
  -D WATCHDOG_STM32=1
  -D DEBUG
 
-[env:maple_mini_bootl_v1_CC1101@debug]
+[env:MAPLEMINI_F103CBcc1101@debug]
 ; ST-Microelectronics STM32F103C8T6 bootloader v1.0
 ; RAM:   [===       ]  29.5% (used 6032 bytes from 20480 bytes)
 ; Flash: [=====     ]  49.6% (used 54852 bytes from 110592 bytes)
@@ -193,7 +193,7 @@ build_flags = ${env_maple_mini.build_flags}
  -D OTHER_BOARD_WITH_CC1101=1
  -D DEBUG
 
-[env:maple_mini_bootl_v1_CC1101]
+[env:MAPLEMINI_F103CBcc1101]
 ; ST-Microelectronics STM32F103C8T6 bootloader v1.0
 ; RAM:   [===       ]  29.5% (used 6032 bytes from 20480 bytes)
 ; Flash: [=====     ]  46.6% (used 51568 bytes from 110592 bytes)
@@ -208,7 +208,7 @@ build_flags = ${env_maple_mini.build_flags}
  -D ARDUINO_MAPLEMINI_F103CB=1
  -D OTHER_BOARD_WITH_CC1101=1
 
-[env:maple_mini_bootl_v1]
+[env:MAPLEMINI_F103CB]
 ; ST-Microelectronics STM32F103C8T6 bootloader v1.0
 ; RAM:   [===       ]  29.1% (used 5968 bytes from 20480 bytes)
 ; Flash: [====      ]  41.7% (used 46144 bytes from 110592 bytes)
@@ -354,6 +354,20 @@ monitor_port = ${env.monitor_port}
 upload_port = ${env.upload_port}
 build_flags=-D OTHER_BOARD_WITH_CC1101=1 -D DEBUG
 
+[env:nano328]
+platform = atmelavr
+board = nanoatmega328
+build_flags=
+framework = arduino
+build_src_filter = -cc1101.h -cc1101.cpp +<*> -<.git/> -<.svn/> -<example/> -<examples/> -<arduino-ide/SIGNALDuino/> -<_micro-api/libraries/ArduinoJson/test/> -<_micro-api/libraries/ArduinoJson/third-party/> -<_micro-api/libraries/fastdelegate/examples/>-<test/> -<tests/> -<_micro-api/libraries/ArduinoJson/fuzzing/>
+
+[env:nanoCC1101]
+platform = atmelavr
+board = nanoatmega328
+framework = arduino
+build_flags=-D OTHER_BOARD_WITH_CC1101=1
+build_src_filter = -cc1101.h -cc1101.cpp +<*> -<.git/> -<.svn/> -<example/> -<examples/> -<arduino-ide/SIGNALDuino/> -<_micro-api/libraries/ArduinoJson/test/> -<_micro-api/libraries/ArduinoJson/third-party/> -<_micro-api/libraries/fastdelegate/examples/>-<test/> -<tests/> -<_micro-api/libraries/ArduinoJson/fuzzing/>
+
 [env:nano_bootl_old_CC1101]
 ; Arduino Nano ATmega328 - bootloader ATmegaBOOT
 ; RAM:   [====      ]  45.0% (used 921 bytes from 2048 bytes)
@@ -487,7 +501,7 @@ monitor_port = ${env.monitor_port}
 upload_port = ${env.upload_port}
 build_flags=
 
-[env:radino_CC1101@debug]
+[env:radinoCC1101@debug]
 ; Arduino compatible (Arduino Micro / Leonardo) - Atmel ATmega32U4
 ; RAM:   [===       ]  41.9% (used 1072 bytes from 2560 bytes)
 ; Flash: [==========]  104.4% (used 29942 bytes from 28672 bytes)
@@ -504,7 +518,7 @@ monitor_port = ${env.monitor_port}
 upload_port = ${env.upload_port}
 build_flags=-D ARDUINO_RADINOCC1101=1 -D DEBUG
 
-[env:radino_CC1101]
+[env:radinoCC1101]
 ; Arduino compatible (Arduino Micro / Leonardo) - Atmel ATmega32U4
 ; RAM:   [===       ]  34.5% (used 882 bytes from 2560 bytes)
 ; Flash: [========= ]  94.6% (used 27114 bytes from 28672 bytes)
@@ -521,7 +535,7 @@ monitor_port = ${env.monitor_port}
 upload_port = ${env.upload_port}
 build_flags=-D ARDUINO_RADINOCC1101=1
 
-[env:          - envName: radino_CC1101@debug]
+[env:wemos_d1_mini_pro_CC1101@debug]
 ; Espressif ESP8266 WeMos D1 mini pro - single core, max 160MHz, GPIO 11, power consumption 70 mA
 ; RAM:   [====      ]  39.4% (used 32260 bytes from 81920 bytes)
 ; Flash: [====      ]  35.8% (used 373456 bytes from 1044464 bytes)

--- a/platformio.ini
+++ b/platformio.ini
@@ -30,7 +30,7 @@ test_dir = tests/
 build_src_filter = +<*> -<.git/> -<.svn/> -<example/> -<examples/> -<arduino-ide/SIGNALDuino/> -<_micro-api/libraries/ArduinoJson/test/> -<_micro-api/libraries/ArduinoJson/third-party/> -<_micro-api/libraries/fastdelegate/examples/>-<test/> -<tests/> -<_micro-api/libraries/ArduinoJson/fuzzing/>
 lib_extra_dirs = src/_micro-api/libraries/
 #debug_port = COM6
-#monitor_port = COM6
+#monitor_port = COM6f
 #upload_port = COM6
 upload_speed = 921600
 
@@ -302,6 +302,7 @@ monitor_port = ${env.monitor_port}
 upload_port = ${env.upload_port}
 build_flags=-D OTHER_BOARD_WITH_CC1101=1
 
+
 [env:nano_bootl_new@debug]
 ; Arduino Nano ATmega328 - bootloader Optiboot
 ; RAM:   [=====     ]  51.3% (used 1050 bytes from 2048 bytes)
@@ -314,6 +315,20 @@ monitor_port = ${env.monitor_port}
 upload_port = ${env.upload_port}
 build_flags = -D DEBUG
 build_src_filter = -cc1101.h -cc1101.cpp +<*> -<.git/> -<.svn/> -<example/> -<examples/> -<arduino-ide/SIGNALDuino/> -<_micro-api/libraries/ArduinoJson/test/> -<_micro-api/libraries/ArduinoJson/third-party/> -<_micro-api/libraries/fastdelegate/examples/>-<test/> -<tests/> -<_micro-api/libraries/ArduinoJson/fuzzing/>
+
+
+[env:nano_bootl_new]
+; Arduino Nano ATmega328 - bootloader Optiboot
+; RAM:   [====      ]  42.1% (used 862 bytes from 2048 bytes)
+; Flash: [=======   ]  69.8% (used 21452 bytes from 30720 bytes)
+platform = atmelavr
+board = nanoatmega328new
+monitor_speed = 57600
+framework = arduino
+monitor_port = ${env.monitor_port}
+upload_port = ${env.upload_port}
+build_flags=
+
 
 [env:io]
 ; Arduino Nano ATmega328 - bootloader Optiboot

--- a/platformio.ini
+++ b/platformio.ini
@@ -36,7 +36,7 @@ upload_speed = 921600
 
 ; file for Advanced Scripting
 ; https://docs.platformio.org/en/latest/projectconf/advanced_scripting.html
-extra_scripts = pre:extra_script.py                             ; to rename projectfile
+extra_scripts = pre:extra_script.py         ; to rename projectfile
 
 [env_esp]
 ; all options for ESP
@@ -315,7 +315,7 @@ upload_port = ${env.upload_port}
 build_flags = -D DEBUG
 build_src_filter = -cc1101.h -cc1101.cpp +<*> -<.git/> -<.svn/> -<example/> -<examples/> -<arduino-ide/SIGNALDuino/> -<_micro-api/libraries/ArduinoJson/test/> -<_micro-api/libraries/ArduinoJson/third-party/> -<_micro-api/libraries/fastdelegate/examples/>-<test/> -<tests/> -<_micro-api/libraries/ArduinoJson/fuzzing/>
 
-[env:nano_bootl_new]
+[env:io]
 ; Arduino Nano ATmega328 - bootloader Optiboot
 ; RAM:   [====      ]  42.1% (used 862 bytes from 2048 bytes)
 ; Flash: [=======   ]  70.2% (used 21564 bytes from 30720 bytes)
@@ -506,7 +506,7 @@ monitor_port = ${env.monitor_port}
 upload_port = ${env.upload_port}
 build_flags=-D ARDUINO_RADINOCC1101=1
 
-[env:wemos_d1_mini_pro_CC1101@debug]
+[env:          - envName: radino_CC1101@debug]
 ; Espressif ESP8266 WeMos D1 mini pro - single core, max 160MHz, GPIO 11, power consumption 70 mA
 ; RAM:   [====      ]  39.4% (used 32260 bytes from 81920 bytes)
 ; Flash: [====      ]  35.8% (used 373456 bytes from 1044464 bytes)

--- a/src/compile_config.h
+++ b/src/compile_config.h
@@ -44,7 +44,9 @@
  * ****************************************
 */
 
-#define PROGVERS               "3.5.1+20230125"
+#ifndef PROGVERS
+  #define PROGVERS               "3.5.1+20230125"   // platformio will set this to the correct value (lateste tag with commits since latest tag)
+#endif
 
 #ifdef OTHER_BOARD_WITH_CC1101
   #define CMP_CC1101

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -97,4 +97,5 @@ include_directories(
 )
 
 enable_testing()
-add_test(all_tests TestProject)
+gtest_discover_tests(TestProject)
+#add_test(testSamesign TestProject)


### PR DESCRIPTION
- [x] PIO Environment nano_bootl_new  added
- [x] GH Actions uses **Platformio for building firmware**
- [x] **PROGVERS is created automatic** by last tag and counted if needed
- [x] Cache cmake libs already build
- [x] Store size repors in Github Actions Step summary
       Example: https://github.com/RFD-FHEM/SIGNALDuino/actions/runs/4840227367#summary-13122256793
- [x] Release is created after all artifacts are created
   Example:  https://github.com/RFD-FHEM/SIGNALDuino/releases


Updated hardware attribute:
https://github.com/RFD-FHEM/RFFHEM/pull/1172