### PR TITLE
fix: compatible env names for platformio > 6.1.6

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -80,7 +80,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install PlatformIO Core
-        run: pip install --upgrade platformio==6.1.6
+        run: pip install --upgrade platformio
 
       - name: Run PlatformIO and compile sketch
         id: compile_sketch

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,19 +10,19 @@
 
 [platformio]
 ; https://docs.platformio.org/en/latest/projectconf/section_env.html
-; default_envs = esp32_CC1101@debug, esp32_CC1101, esp32@debug, esp32
-; default_envs = esp8266_CC1101@debug, esp8266_CC1101, esp8266@debug, esp8266
-; default_envs = maple_mini_bootl_v1_CC1101@debug_wr, maple_mini_bootl_v1_CC1101@debug, maple_mini_bootl_v1_CC1101, maple_mini_bootl_v1
-; default_envs = maple_mini_bootl_v2_CC1101@debug_wr, maple_mini_bootl_v2_CC1101@debug, maple_mini_bootl_v2_CC1101, maple_mini_bootl_v2
-; default_envs = nano_bootl_new_CC1101@debug, nano_bootl_new_CC1101, nano_bootl_new@debug, nano_bootl_new
-; default_envs = nano_bootl_old_CC1101@debug, nano_bootl_old_CC1101, nano_bootl_old@debug, nano_bootl_old
-; default_envs = pro_promini_16MHz_CC1101@debug, pro_promini_16MHz_CC1101, pro_promini_16MHz@debug, pro_promini_16MHz
-; default_envs = pro_promini_8MHz_CC1101@debug, pro_promini_8MHz_CC1101, pro_promini_8MHz@debug, pro_promini_8MHz
-; default_envs = radino_CC1101@debug, radino_CC1101
-; default_envs = wemos_d1_mini_pro_CC1101@debug, wemos_d1_mini_pro_CC1101, wemos_d1_mini_pro@debug, wemos_d1_mini_pro
+; default_envs = esp32_CC1101_debug, esp32_CC1101, esp32_debug, esp32
+; default_envs = esp8266_CC1101_debug, esp8266_CC1101, esp8266_debug, esp8266
+; default_envs = maple_mini_bootl_v1_CC1101_debug_wr, maple_mini_bootl_v1_CC1101_debug, maple_mini_bootl_v1_CC1101, maple_mini_bootl_v1
+; default_envs = maple_mini_bootl_v2_CC1101_debug_wr, maple_mini_bootl_v2_CC1101_debug, maple_mini_bootl_v2_CC1101, maple_mini_bootl_v2
+; default_envs = nano_bootl_new_CC1101_debug, nano_bootl_new_CC1101, nano_bootl_new_debug, nano_bootl_new
+; default_envs = nano_bootl_old_CC1101_debug, nano_bootl_old_CC1101, nano_bootl_old_debug, nano_bootl_old
+; default_envs = pro_promini_16MHz_CC1101_debug, pro_promini_16MHz_CC1101, pro_promini_16MHz_debug, pro_promini_16MHz
+; default_envs = pro_promini_8MHz_CC1101_debug, pro_promini_8MHz_CC1101, pro_promini_8MHz_debug, pro_promini_8MHz
+; default_envs = radino_CC1101_debug, radino_CC1101
+; default_envs = wemos_d1_mini_pro_CC1101_debug, wemos_d1_mini_pro_CC1101, wemos_d1_mini_pro_debug, wemos_d1_mini_pro
 
 ; only SIGNALDECODER DEBUG firmware versions based on ESP8266
-; default_envs = SDC@DEBUG_1, SDC@DEBUGDECODE_1, SDC@DEBUGDECODE_255, SDC@DEBUGDETECT_0, SDC@DEBUGDETECT_1, SDC@DEBUGDETECT_2, SDC@DEBUGDETECT_3, SDC@DEBUGDETECT_3_DEBUGDECODE_1, SDC@DEBUGDETECT_255, SDC@DEBUGDETECT_255_DEBUGDECODE_1
+; default_envs = SDC_DEBUG_1, SDC_DEBUGDECODE_1, SDC_DEBUGDECODE_255, SDC_DEBUGDETECT_0, SDC_DEBUGDETECT_1, SDC_DEBUGDETECT_2, SDC_DEBUGDETECT_3, SDC_DEBUGDETECT_3_DEBUGDECODE_1, SDC_DEBUGDETECT_255, SDC_DEBUGDETECT_255_DEBUGDECODE_1
 
 test_dir = tests/
 
@@ -66,7 +66,7 @@ build_flags=
 ; behind this lines, all hardware projects
 ; * * * * * * * * * * * * * * * * * * * * *
 
-[env:esp32CC1101@debug]
+[env:esp32CC1101_debug]
 platform = espressif32@6.0.1
 board = nodemcu-32s
 framework = arduino
@@ -84,7 +84,7 @@ monitor_port = ${env_esp.monitor_port}
 upload_port = ${env.upload_port}
 build_flags=-D OTHER_BOARD_WITH_CC1101=1
 
-[env:esp32s@debug]
+[env:esp32s_debug]
 platform = espressif32@6.0.1
 board = nodemcu-32s
 framework = arduino
@@ -104,7 +104,7 @@ monitor_port = ${env_esp.monitor_port}
 upload_port = ${env.upload_port}
 build_flags=
 
-[env:esp8266CC1101@debug]
+[env:esp8266CC1101_debug]
 ; Espressif ESP8266 - single core, max 160 MHz, GPIO 17, power consumption 80 mA
 ; RAM:   [====      ]  39.4% (used 32260 bytes from 81920 bytes)
 ; Flash: [====      ]  35.8% (used 373456 bytes from 1044464 bytes)
@@ -132,7 +132,7 @@ monitor_speed = 115200
 lib_deps =
 build_flags=-D OTHER_BOARD_WITH_CC1101=1
 
-[env:esp8266@debug]
+[env:esp8266_debug]
 ; Espressif ESP8266 - single core, max 160 MHz, GPIO 17, power consumption 80 mA
 ; RAM:   [====      ]  39.3% (used 32196 bytes from 81920 bytes)
 ; Flash: [====      ]  35.2% (used 367292 bytes from 1044464 bytes)
@@ -160,7 +160,7 @@ monitor_speed = 115200
 lib_deps=
 build_flags=
 
-[env:MAPLEMINI_F103CB@debug_wr]
+[env:MAPLEMINI_F103CB_debug_wr]
 ; ST-Microelectronics STM32F103C8T6 bootloader v1.0
 ; RAM:   [===       ]  29.5% (used 6032 bytes from 20480 bytes)
 ; Flash: [=====     ]  50.3% (used 55600 bytes from 110592 bytes)
@@ -177,7 +177,7 @@ build_flags = ${env_maple_mini.build_flags}
  -D WATCHDOG_STM32=1
  -D DEBUG
 
-[env:MAPLEMINI_F103CBcc1101@debug]
+[env:MAPLEMINI_F103CBcc1101_debug]
 ; ST-Microelectronics STM32F103C8T6 bootloader v1.0
 ; RAM:   [===       ]  29.5% (used 6032 bytes from 20480 bytes)
 ; Flash: [=====     ]  49.6% (used 54852 bytes from 110592 bytes)
@@ -222,7 +222,7 @@ upload_port = ${env.upload_port}
 build_flags = ${env_maple_mini.build_flags}
  -D ARDUINO_MAPLEMINI_F103CB=1
 
-;[env:maple_mini_bootl_v2_CC1101@debug_wr]
+;[env:maple_mini_bootl_v2_CC1101_debug_wr]
 ; !!! now, error when compiling with PlatformIO (general problem) !!!
 ; ST-Microelectronics STM32F103C8T6 bootloader v2.0
 ; RAM:   [==        ]  16.2% (used 3324 bytes from 20480 bytes)
@@ -236,7 +236,7 @@ build_flags = ${env_maple_mini.build_flags}
 ;upload_port = ${env.upload_port}
 ;build_flags=-D ARDUINO_MAPLEMINI_F103CB=1 -D OTHER_BOARD_WITH_CC1101=1 -D WATCHDOG_STM32=1 -D DEBUG
 
-;[env:maple_mini_bootl_v2_CC1101@debug]
+;[env:maple_mini_bootl_v2_CC1101_debug]
 ; !!! now, error when compiling with PlatformIO (general problem) !!!
 ; ST-Microelectronics STM32F103C8T6 bootloader v2.0
 ; RAM:   [==        ]  16.2% (used 3316 bytes from 20480 bytes)
@@ -278,7 +278,7 @@ build_flags = ${env_maple_mini.build_flags}
 ;upload_port = ${env.upload_port}
 ;build_flags=-D ARDUINO_MAPLEMINI_F103CB=1
 
-[env:nano_bootl_new_CC1101@debug]
+[env:nano_bootl_new_CC1101_debug]
 ; Arduino Nano ATmega328 - bootloader Optiboot
 ; RAM:   [=====     ]  54.2% (used 1109 bytes from 2048 bytes)
 ; Flash: [========= ]  90.0% (used 27638 bytes from 30720 bytes)
@@ -303,7 +303,7 @@ upload_port = ${env.upload_port}
 build_flags=-D OTHER_BOARD_WITH_CC1101=1
 
 
-[env:nano_bootl_news@debug]
+[env:nano_bootl_news_debug]
 ; Arduino Nano ATmega328 - bootloader Optiboot
 ; RAM:   [=====     ]  51.3% (used 1050 bytes from 2048 bytes)
 ; Flash: [========  ]  77.2% (used 23724 bytes from 30720 bytes)
@@ -341,7 +341,7 @@ monitor_port = ${env.monitor_port}
 upload_port = ${env.upload_port}
 build_flag = -D ARDUINO_ATMEGA328P_MINICUL=1
 
-[env:miniculCC1101@debug]
+[env:miniculCC1101_debug]
 ; Minicul with cc1101 running at 8 mhz
 ; RAM:   [====      ]  42.1% (used 862 bytes from 2048 bytes)
 ; Flash: [=======   ]  69.7% (used 21406 bytes from 30720 bytes)
@@ -366,7 +366,7 @@ monitor_port = ${env.monitor_port}
 upload_port = ${env.upload_port}
 build_flags=
 
-[env:nano_bootl_old_CC1101@debug]
+[env:nano_bootl_old_CC1101_debug]
 ; Arduino Nano ATmega328 - bootloader ATmegaBOOT
 ; RAM:   [=====     ]  54.2% (used 1109 bytes from 2048 bytes)
 ; Flash: [========= ]  90.0% (used 27638 bytes from 30720 bytes)
@@ -404,7 +404,7 @@ monitor_port = ${env.monitor_port}
 upload_port = ${env.upload_port}
 build_flags=-D OTHER_BOARD_WITH_CC1101=1
 
-[env:nano_bootl_old@debug]
+[env:nano_bootl_old_debug]
 ; Arduino Nano ATmega328 - bootloader ATmegaBOOT
 ; RAM:   [=====     ]  51.3% (used 1050 bytes from 2048 bytes)
 ; Flash: [========  ]  77.2% (used 23724 bytes from 30720 bytes)
@@ -429,7 +429,7 @@ monitor_port = ${env.monitor_port}
 upload_port = ${env.upload_port}
 build_flags=
 
-[env:promini16CC1101@debug]
+[env:promini16CC1101_debug]
 ; Arduino Pro or Pro Mini - Atmel ATmega328 running at 16MHz
 ; RAM:   [=====     ]  54.2% (used 1109 bytes from 2048 bytes)
 ; Flash: [========= ]  90.0% (used 27638 bytes from 30720 bytes)
@@ -453,7 +453,7 @@ monitor_port = ${env.monitor_port}
 upload_port = ${env.upload_port}
 build_flags=-D OTHER_BOARD_WITH_CC1101=1 
 
-[env:promini16s@debug]
+[env:promini16s_debug]
 ; Arduino Pro or Pro Mini - Atmel ATmega328 running at 8MHz
 ; RAM:   [=====     ]  51.3% (used 1050 bytes from 2048 bytes)
 ; Flash: [========  ]  77.2% (used 23724 bytes from 30720 bytes)
@@ -477,7 +477,7 @@ monitor_port = ${env.monitor_port}
 upload_port = ${env.upload_port}
 build_flags=
 
-[env:promini8CC1101@debug]
+[env:promini8CC1101_debug]
 ; Arduino Pro or Pro Mini - Atmel ATmega328 running at 8MHz
 ; RAM:   [=====     ]  53.8% (used 1101 bytes from 2048 bytes)
 ; Flash: [========= ]  90.1% (used 27684 bytes from 30720 bytes)
@@ -501,7 +501,7 @@ monitor_port = ${env.monitor_port}
 upload_port = ${env.upload_port}
 build_flags=-D OTHER_BOARD_WITH_CC1101=1
 
-[env:promini8s@debug]
+[env:promini8s_debug]
 ; Arduino Pro or Pro Mini - Atmel ATmega328 running at 8MHz
 ; RAM:   [=====     ]  50.9% (used 1042 bytes from 2048 bytes)
 ; Flash: [========  ]  77.4% (used 23768 bytes from 30720 bytes)
@@ -525,7 +525,7 @@ monitor_port = ${env.monitor_port}
 upload_port = ${env.upload_port}
 build_flags=
 
-[env:radinoCC1101@debug]
+[env:radinoCC1101_debug]
 ; Arduino compatible (Arduino Micro / Leonardo) - Atmel ATmega32U4
 ; RAM:   [===       ]  41.9% (used 1072 bytes from 2560 bytes)
 ; Flash: [==========]  104.4% (used 29942 bytes from 28672 bytes)
@@ -559,7 +559,7 @@ monitor_port = ${env.monitor_port}
 upload_port = ${env.upload_port}
 build_flags=-D ARDUINO_RADINOCC1101=1
 
-[env:wemos_d1_mini_pro_CC1101@debug]
+[env:wemos_d1_mini_pro_CC1101_debug]
 ; Espressif ESP8266 WeMos D1 mini pro - single core, max 160MHz, GPIO 11, power consumption 70 mA
 ; RAM:   [====      ]  39.4% (used 32260 bytes from 81920 bytes)
 ; Flash: [====      ]  35.8% (used 373456 bytes from 1044464 bytes)
@@ -584,7 +584,7 @@ monitor_port = ${env.monitor_port}
 upload_port = ${env.upload_port}
 build_flags=-D PIN_LED_INVERSE=1 -D OTHER_BOARD_WITH_CC1101=1
 
-[env:wemos_d1_mini_pros@debug]
+[env:wemos_d1_mini_pros_debug]
 ; Espressif ESP8266 WeMos D1 mini pro - single core, max 160MHz, GPIO 11, power consumption 70 mA
 ; RAM:   [====      ]  39.1% (used 32052 bytes from 81920 bytes)
 ; Flash: [====      ]  35.2% (used 367404 bytes from 1044464 bytes)
@@ -612,7 +612,7 @@ build_flags=-D PIN_LED_INVERSE=1
 ; only SIGNALDECODER DEBUG firmware versions based on ESP8266
 ; -----------------------------------------------------------
 
-[env:SDC@DEBUG_1]
+[env:SDC_DEBUG_1]
 ; 80KB RAM, 4MB Flash
 ; RAM:   [====      ]  40.6% (used 33252 bytes from 81920 bytes)
 ; Flash: [====      ]  36.1% (used 376661 bytes from 1044464 bytes)
@@ -626,7 +626,7 @@ monitor_speed = 115200
 lib_deps =
 build_flags=-D OTHER_BOARD_WITH_CC1101=1 -D DEBUG=1
 
-[env:SDC@DEBUGDECODE_1]
+[env:SDC_DEBUGDECODE_1]
 ; 80KB RAM, 4MB Flash
 ; RAM:   [====      ]  40.9% (used 33508 bytes from 81920 bytes)
 ; Flash: [====      ]  36.2% (used 378285 bytes from 1044464 bytes)
@@ -640,7 +640,7 @@ monitor_speed = 115200
 lib_deps =
 build_flags=-D OTHER_BOARD_WITH_CC1101=1 -D DEBUG -D DEBUGDECODE=1
 
-[env:SDC@DEBUGDECODE_255]
+[env:SDC_DEBUGDECODE_255]
 ; 80KB RAM, 4MB Flash
 ; RAM:   [====      ]  41.0% (used 33572 bytes from 81920 bytes)
 ; Flash: [====      ]  36.2% (used 378317 bytes from 1044464 bytes)
@@ -654,7 +654,7 @@ monitor_speed = 115200
 lib_deps =
 build_flags=-D OTHER_BOARD_WITH_CC1101=1 -D DEBUG=1 -D DEBUGDECODE=255
 
-[env:SDC@DEBUGDETECT_0]
+[env:SDC_DEBUGDETECT_0]
 ; 80KB RAM, 4MB Flash
 ; RAM:   [====      ]  40.6% (used 33284 bytes from 81920 bytes)
 ; Flash: [====      ]  36.1% (used 376789 bytes from 1044464 bytes)
@@ -668,7 +668,7 @@ monitor_speed = 115200
 lib_deps =
 build_flags=-D OTHER_BOARD_WITH_CC1101=1 -D DEBUG=1 -D DEBUGDETECT=0
 
-[env:SDC@DEBUGDETECT_1]
+[env:SDC_DEBUGDETECT_1]
 ; 80KB RAM, 4MB Flash
 ; RAM:   [====      ]  41.0% (used 33576 bytes from 81920 bytes)
 ; Flash: [====      ]  36.2% (used 377657 bytes from 1044464 bytes)
@@ -682,7 +682,7 @@ monitor_speed = 115200
 lib_deps =
 build_flags=-D OTHER_BOARD_WITH_CC1101=1 -D DEBUG=1 -D DEBUGDETECT=1
 
-[env:SDC@DEBUGDETECT_2]
+[env:SDC_DEBUGDETECT_2]
 ; 80KB RAM, 4MB Flash
 ; RAM:   [====      ]  41.0% (used 33572 bytes from 81920 bytes)
 ; Flash: [====      ]  36.2% (used 377709 bytes from 1044464 bytes)
@@ -696,7 +696,7 @@ monitor_speed = 115200
 lib_deps =
 build_flags=-D OTHER_BOARD_WITH_CC1101=1 -D DEBUG=1 -D DEBUGDETECT=2
 
-[env:SDC@DEBUGDETECT_3]
+[env:SDC_DEBUGDETECT_3]
 ; 80KB RAM, 4MB Flash
 ; RAM:   [====      ]  41.1% (used 33640 bytes from 81920 bytes)
 ; Flash: [====      ]  36.2% (used 378153 bytes from 1044464 bytes)
@@ -710,7 +710,7 @@ monitor_speed = 115200
 lib_deps =
 build_flags=-D OTHER_BOARD_WITH_CC1101=1 -D DEBUG=1 -D DEBUGDETECT=3
 
-[env:SDC@DEBUGDETECT_3_DEBUGDECODE_1]
+[env:SDC_DEBUGDETECT_3_DEBUGDECODE_1]
 ; 80KB RAM, 4MB Flash
 ; RAM:   [====      ]  41.4% (used 33896 bytes from 81920 bytes)
 ; Flash: [====      ]  36.4% (used 379809 bytes from 1044464 bytes)
@@ -724,7 +724,7 @@ monitor_speed = 115200
 lib_deps =
 build_flags=-D OTHER_BOARD_WITH_CC1101=1 -D DEBUG=1 -D DEBUGDETECT=3 -D DEBUGDECODE=1
 
-[env:SDC@DEBUGDETECT_255]
+[env:SDC_DEBUGDETECT_255]
 ; 80KB RAM, 4MB Flash
 ; RAM:   [====      ]  41.2% (used 33768 bytes from 81920 bytes)
 ; Flash: [====      ]  36.2% (used 378553 bytes from 1044464 bytes)
@@ -738,7 +738,7 @@ monitor_speed = 115200
 lib_deps =
 build_flags=-D OTHER_BOARD_WITH_CC1101=1 -D DEBUG=1 -D DEBUGDETECT=255
 
-[env:SDC@DEBUGDETECT_255_DEBUGDECODE_1]
+[env:SDC_DEBUGDETECT_255_DEBUGDECODE_1]
 ; 80KB RAM, 4MB Flash
 ; RAM:   [====      ]  41.5% (used 34020 bytes from 81920 bytes)
 ; Flash: [====      ]  36.4% (used 380213 bytes from 1044464 bytes)


### PR DESCRIPTION
fix: compatible env names for platformio > 6.1.6