### PR TITLE
fix: build flags for miniculCC1101 builds

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -339,8 +339,8 @@ framework = arduino
 monitor_speed = 57600
 monitor_port = ${env.monitor_port}
 upload_port = ${env.upload_port}
-build_flag = -D ARDUINO_ATMEGA328P_MINICUL=1
-
+build_flags = -D ARDUINO_ATMEGA328P_MINICUL=1
+ 
 [env:miniculCC1101_debug]
 ; Minicul with cc1101 running at 8 mhz
 ; RAM:   [====      ]  42.1% (used 862 bytes from 2048 bytes)
@@ -351,7 +351,7 @@ framework = arduino
 monitor_speed = 57600
 monitor_port = ${env.monitor_port}
 upload_port = ${env.upload_port}
-build_flag = -D ARDUINO_ATMEGA328P_MINICUL=1 -D DEBUG
+build_flags = -D ARDUINO_ATMEGA328P_MINICUL=1 -D DEBUG
 
 
 [env:io]


### PR DESCRIPTION

Fixes minicul Build mentioned in #290 


### Size report for commit: 040e836a09bae3569b6e4d864b9bba99d0acded8
| ENV | Flash | Ram |
|-------|-------|-----|
| miniculCC1101 | Flash: [========  ]  79.9% (used 24550 bytes from 30720 bytes) | RAM:   [====      ]  44.2% (used 905 bytes from 2048 bytes) |