### PR TITLE
Compiler warnings removed

### DIFF
--- a/src/cc1101.cpp
+++ b/src/cc1101.cpp
@@ -559,9 +559,8 @@ void cc1101::CCinit(void) {                                // initialize CC1101
 }
 
 
-void cc1101::getRxFifo(uint16_t Boffs) {           // xFSK
+void cc1101::getRxFifo() {           // xFSK
 	uint8_t fifoBytes;
-	bool dup;                                      // true bei identischen Wiederholungen bei readRXFIFO
 
 	if (isHigh(PIN_RECEIVE)) {                     // wait for CC1100_FIFOTHR given bytes to arrive in FIFO
 		#ifdef PIN_LED_INVERSE

--- a/src/cc1101.h
+++ b/src/cc1101.h
@@ -196,8 +196,8 @@ namespace cc1101 {
 	void CCinit(void);                                              // initialize CC1101
 	void ccFactoryReset();
 	void commandStrobes(void);
-	void getRxFifo(uint16_t Boffs);                                 // xFSK
-    void sendFIFO(char*, char*);                                    // xFSK
+	void getRxFifo();                                               // xFSK
+  void sendFIFO(char*, char*);                                    // xFSK
 	void readCCreg(const uint8_t reg);                              // read CC1101 register
 	void readPatable(void);
 	void setIdleMode();

--- a/src/compile_config.h
+++ b/src/compile_config.h
@@ -45,7 +45,7 @@
 */
 
 #ifndef PROGVERS
-  #define PROGVERS               "4.0.4+20230814"   // platformio will set this to the correct value (lateste tag with commits since latest tag)
+  #define PROGVERS               "4.0.5+20230814"   // platformio will set this to the correct value (lateste tag with commits since latest tag)
 #endif
 
 #ifdef OTHER_BOARD_WITH_CC1101

--- a/src/signalSTM.h
+++ b/src/signalSTM.h
@@ -218,7 +218,7 @@ void loop() {
 #ifdef CMP_CC1101
   } else {
     if (wmbus == 0) {
-      cc1101::getRxFifo(0);                   // xFSK = 0
+      cc1101::getRxFifo();                   // xFSK = 0
     } else {
       mbus_task();
     }

--- a/src/signalduino.h
+++ b/src/signalduino.h
@@ -230,7 +230,7 @@ void loop() {
       }
   #ifdef CMP_CC1101
     } else {
-      cc1101::getRxFifo(0);                   // xFSK = 0
+      cc1101::getRxFifo();                   // xFSK = 0
     }
   #endif
 }

--- a/src/signalesp.h
+++ b/src/signalesp.h
@@ -347,7 +347,7 @@ void loop() {
 #ifdef CMP_CC1101
   } else {
     if (wmbus == 0) {
-      cc1101::getRxFifo(0);                   // xFSK = 0
+      cc1101::getRxFifo();                   // xFSK = 0
     } else {
       mbus_task();
     }


### PR DESCRIPTION
warning: unused variable 'dup'
warning: unused parameter 'Boffs'