### PR TITLE
Compiler warnings removed 1

### DIFF
--- a/src/_micro-api/libraries/bitstore/src/bitstore.h
+++ b/src/_micro-api/libraries/bitstore/src/bitstore.h
@@ -32,7 +32,7 @@ public:
 	//~BitStore();
 	bool addValue(byte value);
 	int8_t getValue(const uint16_t pos);
-	bool moveLeft(const uint16_t begin);
+	bool moveLeft(const int16_t begin);
 	bool changeValue(const uint16_t pos, byte value);
 
 	const uint16_t getSize();
@@ -206,7 +206,7 @@ const uint16_t BitStore<bufSize>::getSize()
 }
 
 template<uint8_t bufSize>
-bool BitStore<bufSize>::moveLeft(const uint16_t begin)
+bool BitStore<bufSize>::moveLeft(const int16_t begin)
 {
 	if (begin == 0 || begin >= valcount) return false;
 	if (begin == valcount - 1)

--- a/src/_micro-api/libraries/output/src/output.h
+++ b/src/_micro-api/libraries/output/src/output.h
@@ -64,21 +64,21 @@ static const char TXT_WRITE[]           PROGMEM = "write ";
 
 	#ifdef ARDUINO_RADINOCC1101
 		#define portOfPin(P) \
-		((((P) >= 0 && (P) <= 4) || (P) == 6 || (P) == 12 || (P) == 24 || (P) == 25 || (P) == 29) ? &PORTD : (((P) == 5 || (P) == 13) ? &PORTC : (((P) >= 18 && (P) <= 23)) ? &PORTF : (((P) == 7) ? &PORTE : &PORTB)))
+		((((P) <= 4) || (P) == 6 || (P) == 12 || (P) == 24 || (P) == 25 || (P) == 29) ? &PORTD : (((P) == 5 || (P) == 13) ? &PORTC : (((P) >= 18 && (P) <= 23)) ? &PORTF : (((P) == 7) ? &PORTE : &PORTB)))
 		#define ddrOfPin(P) \
-		((((P) >= 0 && (P) <= 4) || (P) == 6 || (P) == 12 || (P) == 24 || (P) == 25 || (P) == 29) ? &DDRD : (((P) == 5 || (P) == 13) ? &DDRC : (((P) >= 18 && (P) <= 23)) ? &DDRF : (((P) == 7) ? &DDRE : &DDRB)))
+		((((P) <= 4) || (P) == 6 || (P) == 12 || (P) == 24 || (P) == 25 || (P) == 29) ? &DDRD : (((P) == 5 || (P) == 13) ? &DDRC : (((P) >= 18 && (P) <= 23)) ? &DDRF : (((P) == 7) ? &DDRE : &DDRB)))
 		#define pinOfPin(P) \
-		((((P) >= 0 && (P) <= 4) || (P) == 6 || (P) == 12 || (P) == 24 || (P) == 25 || (P) == 29) ? &PIND : (((P) == 5 || (P) == 13) ? &PINC : (((P) >= 18 && (P) <= 23)) ? &PINF : (((P) == 7) ? &PINE : &PINB)))
+		((((P) <= 4) || (P) == 6 || (P) == 12 || (P) == 24 || (P) == 25 || (P) == 29) ? &PIND : (((P) == 5 || (P) == 13) ? &PINC : (((P) >= 18 && (P) <= 23)) ? &PINF : (((P) == 7) ? &PINE : &PINB)))
 		#define pinIndex(P) \
 		(((P) >= 8 && (P) <= 11) ? (P) - 4 : (((P) >= 18 && (P) <= 21) ? 25 - (P) : (((P) == 0) ? 2 : (((P) == 1) ? 3 : (((P) == 2) ? 1 : (((P) == 3) ? 0 : (((P) == 4) ? 4 : (((P) == 6) ? 7 : (((P) == 13) ? 7 : (((P) == 14) ? 3 : (((P) == 15) ? 1 : (((P) == 16) ? 2 : (((P) == 17) ? 0 : (((P) == 22) ? 1 : (((P) == 23) ? 0 : (((P) == 24) ? 4 : (((P) == 25) ? 7 : (((P) == 26) ? 4 : (((P) == 27) ? 5 : 6 )))))))))))))))))))
 	#else
 	#ifndef ARDUINO_MAPLEMINI_F103CB
 		#define portOfPin(P)\
-		  (((P)>=0&&(P)<8)?&PORTD:(((P)>7&&(P)<14)?&PORTB:&PORTC))
+			(((P)<8)?&PORTD:(((P)>7&&(P)<14)?&PORTB:&PORTC))
 		#define ddrOfPin(P)\
-		  (((P)>=0&&(P)<8)?&DDRD:(((P)>7&&(P)<14)?&DDRB:&DDRC))
+			(((P)<8)?&DDRD:(((P)>7&&(P)<14)?&DDRB:&DDRC))
 		#define pinOfPin(P)\
-		  (((P)>=0&&(P)<8)?&PIND:(((P)>7&&(P)<14)?&PINB:&PINC))
+		  (((P)<8)?&PIND:(((P)>7&&(P)<14)?&PINB:&PINC))
 		#define pinIndex(P)((uint8_t)(P>13?P-14:P&7))
     #else
       #define pinAsInput(pin) pinMode(pin, INPUT)

--- a/src/_micro-api/libraries/signalDecoder/src/signalDecoder.cpp
+++ b/src/_micro-api/libraries/signalDecoder/src/signalDecoder.cpp
@@ -234,7 +234,7 @@ inline void SignalDetectorClass::doDetect()
 				processMessage();
 				calcHisto();
 			}
-			for (uint8_t i = messageLen - 1 ; i >= 0 && histo[pattern_pos] > 0 && messageLen>0; --i)
+			for (uint8_t i = messageLen - 1 ; histo[pattern_pos] > 0 && messageLen > 0; --i)
 			{
 				if (message[i] == pattern_pos) // Finde den letzten Verweis im Array auf den Index der gleich ueberschrieben wird
 				{
@@ -1091,7 +1091,7 @@ bool SignalDetectorClass::getSync()
 
 		for (int8_t p = patternLen - 1; p >= 0; --p)  // Schleife fuer langen Syncpuls
 		{
-			uint16_t syncabs = abs(pattern[p]);
+			int16_t syncabs = abs(pattern[p]);
 			if ((pattern[p] < 0) &&
 				(syncabs < syncMaxMicros && syncabs / pattern[clock] <= syncMaxFact) &&
 				(syncabs > syncMinFact*pattern[clock]) &&

--- a/src/compile_config.h
+++ b/src/compile_config.h
@@ -45,7 +45,7 @@
 */
 
 #ifndef PROGVERS
-  #define PROGVERS               "4.0.5+20230814"   // platformio will set this to the correct value (lateste tag with commits since latest tag)
+  #define PROGVERS               "4.0.6+20230814"   // platformio will set this to the correct value (lateste tag with commits since latest tag)
 #endif
 
 #ifdef OTHER_BOARD_WITH_CC1101


### PR DESCRIPTION
warning: comparison is always true due to limited range of data type
warning: comparison between signed and unsigned integer expressions