### PR TITLE
ESP8266 compiler warnings removed

### DIFF
--- a/src/compile_config.h
+++ b/src/compile_config.h
@@ -45,7 +45,7 @@
 */
 
 #ifndef PROGVERS
-  #define PROGVERS               "4.0.6+20230814"   // platformio will set this to the correct value (lateste tag with commits since latest tag)
+  #define PROGVERS               "4.0.8+20230814"   // platformio will set this to the correct value (lateste tag with commits since latest tag)
 #endif
 
 #ifdef OTHER_BOARD_WITH_CC1101

--- a/src/signalesp.h
+++ b/src/signalesp.h
@@ -135,7 +135,7 @@ void setup() {
   }
   
 #if defined(ESP8266)
-  gotIpEventHandler = WiFi.onStationModeGotIP([](const WiFiEventStationModeGotIP& event)
+  gotIpEventHandler = WiFi.onStationModeGotIP([](__attribute__((unused)) const WiFiEventStationModeGotIP& event)
   {
     Server.begin();  // start telnet server
     Server.setNoDelay(true); // With nodelay set to true, this function will to disable Nagle algorithm (https://en.wikipedia.org/wiki/Nagle%27s_algorithm).
@@ -254,7 +254,7 @@ initEEPROM();
   esp_timer_create(&cronTimer_args, &cronTimer_handle);
 #elif defined(ESP8266)
   os_timer_disarm(&cronTimer);
-  os_timer_setfn(&cronTimer, &cronjob, 0);
+  os_timer_setfn(&cronTimer, &cronjob, NULL);
 #endif
 
 musterDec.setCallback(writeCallback);
@@ -294,7 +294,7 @@ digitalLow(PIN_LED);
 
 
 
-void IRAM_ATTR cronjob(void *pArg) {
+void IRAM_ATTR cronjob(__attribute__((unused)) void *pArg) {
   cli();
   static uint16_t cnt = 0; // approximately every 35 minutes
 


### PR DESCRIPTION
warning: unused parameter 'event'
warning: unused parameter 'pArg'