### PR TITLE
ESP32 compiler warnings removed

### DIFF
--- a/src/compile_config.h
+++ b/src/compile_config.h
@@ -45,7 +45,7 @@
 */
 
 #ifndef PROGVERS
-  #define PROGVERS               "4.0.8+20230814"   // platformio will set this to the correct value (lateste tag with commits since latest tag)
+  #define PROGVERS               "4.0.9+20230814"   // platformio will set this to the correct value (lateste tag with commits since latest tag)
 #endif
 
 #ifdef OTHER_BOARD_WITH_CC1101


### PR DESCRIPTION
warning: '++' expression of 'volatile'-qualified type is deprecated
warning: '--' expression of 'volatile'-qualified type is deprecated
warning: using value of assignment with 'volatile'-qualified left operand is deprecated