### PR TITLE
ESP32 compiler warnings removed 1

### DIFF
--- a/src/compile_config.h
+++ b/src/compile_config.h
@@ -45,7 +45,7 @@
 */
 
 #ifndef PROGVERS
-  #define PROGVERS               "4.0.9+20230814"   // platformio will set this to the correct value (lateste tag with commits since latest tag)
+  #define PROGVERS               "4.0.10+20230814"   // platformio will set this to the correct value (lateste tag with commits since latest tag)
 #endif
 
 #ifdef OTHER_BOARD_WITH_CC1101


### PR DESCRIPTION
warning: ignoring attribute 'section (".iram1.5")' because it conflicts with previous 'section (".iram1.1")'
warning: ignoring attribute 'section (".iram1.6")' because it conflicts with previous 'section (".iram1.0")'
warning: 'virtual void NetworkClient::flush()' is deprecated: Use clear() instead.