### PR TITLE
fix(esp32): WiFi-Disconnect-Reason aus richtiger Union-Member lesen

### DIFF
--- a/src/signalesp.h
+++ b/src/signalesp.h
@@ -186,8 +186,10 @@ void setup() {
   WiFi.onEvent([](WiFiEvent_t event, WiFiEventInfo_t info) {
     Server.stop();  // end telnet server
     Serial.print("WiFi lost connection. Reason: ");
-    Serial.println(info.wps_fail_reason);
-    
+    // WiFiEventInfo_t ist eine Union — beim STA_DISCONNECTED-Event liegt der
+    // Reason-Code in wifi_sta_disconnected.reason, nicht in wps_fail_reason
+    // (das gehoert zu einem anderen Event-Typ).
+    Serial.println(info.wifi_sta_disconnected.reason);
   }, WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_DISCONNECTED);
 #endif
 


### PR DESCRIPTION
## Symptom

Im Boot-Log und bei jedem WLAN-Disconnect erscheint ein unsinniger Reason-Wert:

Reason-Codes laut `wifi_err_reason_t` sind aber kleine Werte (1–209).

## Ursache

In `src/signalesp.h` wird beim `ARDUINO_EVENT_WIFI_STA_DISCONNECTED`-Event `info.wps_fail_reason` ausgelesen. `WiFiEventInfo_t` ist aber eine Union — bei diesem Event-Typ liegt der Reason in `info.wifi_sta_disconnected.reason`. `wps_fail_reason` gehört zu einem anderen Event und enthält hier zufällige Stack-Bytes.

## Fix

Eine Zeile, plus erklärender Kommentar.

## Test

Auf ESP32 + CC1101 verifiziert: vorher unsinnige Werte, nach dem Fix saubere Reason-Codes (`202` = AUTH_FAIL beim typischen kurzen Re-Auth nach Boot).

## Vergleich

Der ESP8266-Zweig wenige Zeilen darüber macht es bereits richtig: `event.reason` direkt aus dem ESP8266-spezifischen Struct.